### PR TITLE
Fix example LDAP URL

### DIFF
--- a/vertx-auth-shiro/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-shiro/src/main/asciidoc/groovy/index.adoc
@@ -164,7 +164,7 @@ The following configuration properties are used to configure the LDAP realm:
 id. An example is `uid={0},ou=users,dc=foo,dc=com` - the element `{0}` is substituted with the user id to create the
 actual lookup. This setting is mandatory.
 `ldap_url`:: the url to the LDAP server. The url must start with `ldap://` and a port must be specified.
-An example is `ldap:://myldapserver.mycompany.com:10389`
+An example is `ldap://myldapserver.mycompany.com:10389`
 `ldap-authentication-mechanism`:: TODO
 `ldap-context-factory-class-name`:: TODO
 `ldap-pooling-enabled`:: TODO


### PR DESCRIPTION
Please remove the extra colon from the example LDAP URL. Putting an extra colon as shown will cause the following exceptions to be silently thrown.

org.apache.shiro.authc.AuthenticationException: LDAP naming error while attempting to authenticate user.
...
Caused by: javax.naming.InvalidNameException: Invalid name: ://myldapserver.mycompany.com:10389
