### PR TITLE
Bnd configuration

### DIFF
--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -63,7 +63,7 @@
     <plugin>
     <groupId>biz.aQute.bnd</groupId>
     <artifactId>bnd-maven-plugin</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.0</version>
       <executions>
         <execution>
           <id>default-bnd-process</id>

--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -61,28 +61,35 @@
       </executions>
     </plugin>
     <plugin>
-      <groupId>org.apache.felix</groupId>
-      <artifactId>maven-bundle-plugin</artifactId>
-      <version>3.0.0</version>
+    <groupId>biz.aQute.bnd</groupId>
+    <artifactId>bnd-maven-plugin</artifactId>
+    <version>3.2.0-SNAPSHOT</version>
       <executions>
         <execution>
-          <id>bundle-manifest</id>
-          <phase>process-classes</phase>
+          <id>default-bnd-process</id>
           <goals>
-            <goal>manifest</goal>
+            <goal>bnd-process</goal>
           </goals>
-          <configuration>
-            <instructions>
-              <Export-Package>io.vertx.ext.auth*</Export-Package>
-              <Private-Package>!examples*</Private-Package>
-              <Import-Package>
-                *
-              </Import-Package>
-            </instructions>
-          </configuration>
         </execution>
       </executions>
-    </plugin>
+      <configuration>
+        <bnd><![CDATA[
+          Import-Package: \
+            groovy.lang.*;resolution:=optional,\
+            org.codehaus.groovy.*;resolution:=optional,\
+            io.vertx.groovy.*;resolution:=optional,\
+            io.vertx.lang.rxjava.*;resolution:=optional,\
+            io.vertx.lang.groovy.*;resolution:=optional,\
+            io.vertx.codegen.annotations;resolution:=optional,\
+            io.vertx.rx.java;resolution:=optional,\
+            io.vertx.rxjava.core.*;resolution:=optional,\
+            rx.*;resolution:=optional,\
+            *
+          -exportcontents: !*impl, !examples, *
+        ]]></bnd>
+      </configuration>
+  </plugin>
+
   </plugins>
 </build>
 

--- a/vertx-auth-jdbc/pom.xml
+++ b/vertx-auth-jdbc/pom.xml
@@ -53,7 +53,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.2.0</version>
 
         <executions>
           <execution>

--- a/vertx-auth-jdbc/pom.xml
+++ b/vertx-auth-jdbc/pom.xml
@@ -48,5 +48,50 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
 
+        <executions>
+          <execution>
+            <id>default-bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bnd><![CDATA[
+          Import-Package: \
+            groovy.lang.*;resolution:=optional,\
+            io.vertx.codegen.annotations;resolution:=optional,\
+            io.vertx.rxjava.*;resolution:=optional,\
+            io.vertx.lang.groovy.*;resolution:=optional,\
+            org.codehaus.groovy.*;resolution:=optional,\
+            io.vertx.groovy.*;resolution:=optional,\
+            *
+          -exportcontents: !*impl,!examples,*
+          ]]></bnd>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+  </build>
 </project>

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -37,6 +37,54 @@
       <artifactId>vertx-auth-common</artifactId>
     </dependency>
   </dependencies>
+  <build>
 
+  <plugins>
+    <plugin>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>bnd-maven-plugin</artifactId>
+            <version>3.2.0-SNAPSHOT</version>
 
+      <executions>
+        <execution>
+          <id>default-bnd-process</id>
+          <goals>
+            <goal>bnd-process</goal>
+          </goals>
+        </execution>
+      </executions>
+      <configuration>
+        <bnd><![CDATA[
+          Import-Package: \
+            groovy.lang.*;resolution:=optional,\
+            org.codehaus.groovy.*;resolution:=optional,\
+            io.vertx.groovy.*;resolution:=optional,\
+            io.vertx.lang.rxjava.*;resolution:=optional,\
+            io.vertx.lang.groovy.*;resolution:=optional,\
+            io.vertx.codegen.annotations;resolution:=optional,\
+            io.vertx.rx.java;resolution:=optional,\
+            io.vertx.rxjava.core.*;resolution:=optional,\
+            rx.*;resolution:=optional,\
+            *
+          -exportcontents: !*impl, !examples, *
+          ]]></bnd>
+      </configuration>
+          </plugin>
+          <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-jar-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>default-jar</id>
+              <configuration>
+                <archive>
+                  <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                </archive>
+              </configuration>
+            </execution>
+          </executions>
+</plugin>
+  </plugins>
+
+</build>
 </project>

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -39,22 +39,22 @@
   </dependencies>
   <build>
 
-  <plugins>
-    <plugin>
-            <groupId>biz.aQute.bnd</groupId>
-            <artifactId>bnd-maven-plugin</artifactId>
-            <version>3.2.0-SNAPSHOT</version>
+    <plugins>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
 
-      <executions>
-        <execution>
-          <id>default-bnd-process</id>
-          <goals>
-            <goal>bnd-process</goal>
-          </goals>
-        </execution>
-      </executions>
-      <configuration>
-        <bnd><![CDATA[
+        <executions>
+          <execution>
+            <id>default-bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bnd><![CDATA[
           Import-Package: \
             groovy.lang.*;resolution:=optional,\
             org.codehaus.groovy.*;resolution:=optional,\
@@ -68,23 +68,23 @@
             *
           -exportcontents: !*impl, !examples, *
           ]]></bnd>
-      </configuration>
-          </plugin>
-          <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-jar-plugin</artifactId>
-          <executions>
-            <execution>
-              <id>default-jar</id>
-              <configuration>
-                <archive>
-                  <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                </archive>
-              </configuration>
-            </execution>
-          </executions>
-</plugin>
-  </plugins>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <archive>
+                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+              </archive>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
 
 </build>
 </project>

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -43,7 +43,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.2.0</version>
 
         <executions>
           <execution>

--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -65,7 +65,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.2.0</version>
 
         <executions>
           <execution>

--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -52,4 +52,46 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <useDefaultManifestFile>true</useDefaultManifestFile>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+
+        <executions>
+          <execution>
+            <id>default-bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bnd><![CDATA[
+          Import-Package: \
+            groovy.lang.*;resolution:=optional,\
+            org.codehaus.groovy.*;resolution:=optional,\
+            io.vertx.groovy.*;resolution:=optional,\
+            io.vertx.lang.rxjava.*;resolution:=optional,\
+            io.vertx.lang.groovy.*;resolution:=optional,\
+            io.vertx.codegen.annotations;resolution:=optional,\
+            io.vertx.rx.java;resolution:=optional,\
+            io.vertx.rxjava.core.*;resolution:=optional,\
+            rx.*;resolution:=optional,\
+            *
+          -exportcontents: !*impl, !examples, *
+          ]]></bnd>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.2.0</version>
 
         <executions>
           <execution>

--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -37,6 +37,46 @@
       <artifactId>vertx-auth-common</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <useDefaultManifestFile>true</useDefaultManifestFile>
+        </configuration>
+      </plugin>
 
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
 
+        <executions>
+          <execution>
+            <id>default-bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bnd><![CDATA[
+          Import-Package: \
+            groovy.lang.*;resolution:=optional,\
+            org.codehaus.groovy.*;resolution:=optional,\
+            io.vertx.groovy.*;resolution:=optional,\
+            io.vertx.lang.rxjava.*;resolution:=optional,\
+            io.vertx.lang.groovy.*;resolution:=optional,\
+            io.vertx.codegen.annotations;resolution:=optional,\
+            io.vertx.rx.java;resolution:=optional,\
+            io.vertx.rxjava.core.*;resolution:=optional,\
+            rx.*;resolution:=optional,\
+            *
+          -exportcontents: !*impl, !examples, *
+          ]]></bnd>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/vertx-auth-shiro/pom.xml
+++ b/vertx-auth-shiro/pom.xml
@@ -169,7 +169,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>3.2.0-SNAPSHOT</version>
+        <version>3.2.0</version>
 
         <executions>
           <execution>

--- a/vertx-auth-shiro/pom.xml
+++ b/vertx-auth-shiro/pom.xml
@@ -157,6 +157,45 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <useDefaultManifestFile>true</useDefaultManifestFile>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+
+        <executions>
+          <execution>
+            <id>default-bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <bnd><![CDATA[
+          Import-Package: \
+            groovy.lang.*;resolution:=optional,\
+            org.codehaus.groovy.*;resolution:=optional,\
+            io.vertx.groovy.*;resolution:=optional,\
+            io.vertx.lang.rxjava.*;resolution:=optional,\
+            io.vertx.lang.groovy.*;resolution:=optional,\
+            io.vertx.codegen.annotations;resolution:=optional,\
+            io.vertx.rx.java;resolution:=optional,\
+            io.vertx.rxjava.core.*;resolution:=optional,\
+            rx.*;resolution:=optional,\
+            *
+          -exportcontents: !*impl, !examples, *
+          ]]></bnd>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Added bnd configuration to all auth providers to generate OSGi manifests. Test cases are available in a Bndtools workspace here: https://github.com/paulbakker/vertx-osgi-testcases/tree/master

Note that this requires the unreleased bnd-maven-plugin 3.2 plugin.
