### PR TITLE
Do not allow alg none when keystore has algorithms

### DIFF
--- a/vertx-auth-jwt/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/groovy/index.adoc
@@ -93,13 +93,16 @@ if ("paulo" == username && "super_secret" == password) {
 
 ----
 
-TODO show example of authentication and authorisation with JWT and explain how the permission string passed
-in authorisation maps to the claims in the JW token
+// TODO show example of authentication and authorisation with JWT and explain how the permission string passed
+// in authorisation maps to the claims in the JW token
+
 
 === The JWT keystore file
 
-This auth provider requires a keystore in the classpath or in the filesystem with either a `Mac`
-or a `Signature` in order to sign and verify the generated tokens.
+This auth provider requires a keystore in the classpath or in the filesystem with either a
+`https://docs.oracle.com/javase/8/docs/api/javax/crypto/Mac.html[javax.crypto.Mac]`
+or a `https://docs.oracle.com/javase/8/docs/api/java/security/Signature.html[java.security.Signature]` in order to
+sign and verify the generated tokens.
 
 The implementation will, by default, look for the following aliases, however not all are required to be present. As
 a good practice `HS256` should be present:

--- a/vertx-auth-jwt/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/java/index.adoc
@@ -79,13 +79,16 @@ if ("paulo".equals(username) && "super_secret".equals(password)) {
 }
 ----
 
-TODO show example of authentication and authorisation with JWT and explain how the permission string passed
-in authorisation maps to the claims in the JW token
+// TODO show example of authentication and authorisation with JWT and explain how the permission string passed
+// in authorisation maps to the claims in the JW token
+
 
 === The JWT keystore file
 
-This auth provider requires a keystore in the classpath or in the filesystem with either a `link:../../apidocs/javax/crypto/Mac.html[Mac]`
-or a `link:../../apidocs/java/security/Signature.html[Signature]` in order to sign and verify the generated tokens.
+This auth provider requires a keystore in the classpath or in the filesystem with either a
+`https://docs.oracle.com/javase/8/docs/api/javax/crypto/Mac.html[javax.crypto.Mac]`
+or a `https://docs.oracle.com/javase/8/docs/api/java/security/Signature.html[java.security.Signature]` in order to
+sign and verify the generated tokens.
 
 The implementation will, by default, look for the following aliases, however not all are required to be present. As
 a good practice `HS256` should be present:

--- a/vertx-auth-jwt/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/js/index.adoc
@@ -94,13 +94,16 @@ if ("paulo" == username && "super_secret" == password) {
 
 ----
 
-TODO show example of authentication and authorisation with JWT and explain how the permission string passed
-in authorisation maps to the claims in the JW token
+// TODO show example of authentication and authorisation with JWT and explain how the permission string passed
+// in authorisation maps to the claims in the JW token
+
 
 === The JWT keystore file
 
-This auth provider requires a keystore in the classpath or in the filesystem with either a `Mac`
-or a `Signature` in order to sign and verify the generated tokens.
+This auth provider requires a keystore in the classpath or in the filesystem with either a
+`https://docs.oracle.com/javase/8/docs/api/javax/crypto/Mac.html[javax.crypto.Mac]`
+or a `https://docs.oracle.com/javase/8/docs/api/java/security/Signature.html[java.security.Signature]` in order to
+sign and verify the generated tokens.
 
 The implementation will, by default, look for the following aliases, however not all are required to be present. As
 a good practice `HS256` should be present:

--- a/vertx-auth-jwt/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/ruby/index.adoc
@@ -94,13 +94,16 @@ end
 
 ----
 
-TODO show example of authentication and authorisation with JWT and explain how the permission string passed
-in authorisation maps to the claims in the JW token
+// TODO show example of authentication and authorisation with JWT and explain how the permission string passed
+// in authorisation maps to the claims in the JW token
+
 
 === The JWT keystore file
 
-This auth provider requires a keystore in the classpath or in the filesystem with either a `link:unavailable[Mac]`
-or a `link:unavailable[Signature]` in order to sign and verify the generated tokens.
+This auth provider requires a keystore in the classpath or in the filesystem with either a
+`https://docs.oracle.com/javase/8/docs/api/javax/crypto/Mac.html[javax.crypto.Mac]`
+or a `https://docs.oracle.com/javase/8/docs/api/java/security/Signature.html[java.security.Signature]` in order to
+sign and verify the generated tokens.
 
 The implementation will, by default, look for the following aliases, however not all are required to be present. As
 a good practice `HS256` should be present:

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWT.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWT.java
@@ -180,10 +180,17 @@ public final class JWT {
     JsonObject header = new JsonObject(new String(base64urlDecode(headerSeg), UTF8));
     JsonObject payload = new JsonObject(new String(base64urlDecode(payloadSeg), UTF8));
 
-    Crypto crypto = cryptoMap.get(header.getString("alg"));
+    String alg = header.getString("alg");
+
+    Crypto crypto = cryptoMap.get(alg);
 
     if (crypto == null) {
       throw new RuntimeException("Algorithm not supported");
+    }
+
+    // if we only allow secure alg, then none is not a valid option
+    if (!unsecure && "none".equals(alg)) {
+      throw new RuntimeException("Algorithm \"none\" not allowed");
     }
 
     // verify signature. `sign` will return base64 string.


### PR DESCRIPTION
Fixes #66 

The check for unsecure tokens was incomplete, the reported test helped to fix it.
