### PR TITLE
JWT audience can be a array or just single string value, and we shoul…

### DIFF
--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
@@ -117,7 +117,12 @@ public class JWTAuthProviderImpl implements JWTAuth {
 
       if (options.containsKey("audience")) {
         JsonArray audiences = options.getJsonArray("audience", EMPTY_ARRAY);
-        JsonArray target = payload.getJsonArray("aud", EMPTY_ARRAY);
+        JsonArray target;
+        if (payload.getValue("aud") instanceof String) {
+          target = new JsonArray().add(payload.getValue("aud", ""));
+        } else {
+          target = payload.getJsonArray("aud", EMPTY_ARRAY);
+        }
 
         if (Collections.disjoint(audiences.getList(), target.getList())) {
           resultHandler.handle(Future.failedFuture("Invalid JWT audient. expected: " + audiences.encode()));


### PR DESCRIPTION
If client is sending the single "aud" then Vertx-JWT doesn't handle it gracefully.

It's not always necessary for the "aud" to be a JSON array, and it can be just a single string value.
Nowhere in JWT specs I found that "aud" always has to be an array of String.

See https://groups.google.com/forum/#!topic/vertx/7hFYACYMLQs 

Signed-off-by: manishk
