### PR TITLE
Add touch method to the User interface to prevent ShiroUsers from timing out every 30 min

### DIFF
--- a/vertx-auth-common/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-common/src/main/asciidoc/groovy/index.adoc
@@ -14,7 +14,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-common</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -22,7 +22,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-common:3.3.2'
+compile 'io.vertx:vertx-auth-common:3.4.0-SNAPSHOT'
 ----
 
 == Basic concepts

--- a/vertx-auth-common/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-common/src/main/asciidoc/java/index.adoc
@@ -14,7 +14,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-common</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -22,7 +22,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-common:3.3.2'
+compile 'io.vertx:vertx-auth-common:3.4.0-SNAPSHOT'
 ----
 
 == Basic concepts

--- a/vertx-auth-common/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-common/src/main/asciidoc/js/index.adoc
@@ -14,7 +14,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-common</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -22,7 +22,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-common:3.3.2'
+compile 'io.vertx:vertx-auth-common:3.4.0-SNAPSHOT'
 ----
 
 == Basic concepts

--- a/vertx-auth-common/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-common/src/main/asciidoc/ruby/index.adoc
@@ -14,7 +14,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-common</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -22,7 +22,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-common:3.3.2'
+compile 'io.vertx:vertx-auth-common:3.4.0-SNAPSHOT'
 ----
 
 == Basic concepts

--- a/vertx-auth-common/src/main/generated/io/vertx/rxjava/ext/auth/User.java
+++ b/vertx-auth-common/src/main/generated/io/vertx/rxjava/ext/auth/User.java
@@ -99,6 +99,14 @@ public class User {
     delegate.setAuthProvider((io.vertx.ext.auth.AuthProvider)authProvider.getDelegate());
   }
 
+  /**
+   * Reset session timeout counter. For AuthProviders that implement a timeout scheme, this resets the clock
+   * to prevent the Users session from being timed out.
+   */
+  public void touch() { 
+    delegate.touch();
+  }
+
 
   public static User newInstance(io.vertx.ext.auth.User arg) {
     return arg != null ? new User(arg) : null;

--- a/vertx-auth-common/src/main/groovy/io/vertx/groovy/ext/auth/User.groovy
+++ b/vertx-auth-common/src/main/groovy/io/vertx/groovy/ext/auth/User.groovy
@@ -76,4 +76,11 @@ public class User {
   public void setAuthProvider(AuthProvider authProvider) {
     delegate.setAuthProvider(authProvider != null ? (io.vertx.ext.auth.AuthProvider)authProvider.getDelegate() : null);
   }
+  /**
+   * Reset session timeout counter. For AuthProviders that implement a timeout scheme, this resets the clock
+   * to prevent the Users session from being timed out.
+   */
+  public void touch() {
+    delegate.touch();
+  }
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/User.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/User.java
@@ -76,4 +76,10 @@ public interface User {
    * @param authProvider  the AuthProvider - this must be the same type of AuthProvider that originally created the User
    */
   void setAuthProvider(AuthProvider authProvider);
+
+  /**
+   * Reset session timeout counter. For AuthProviders that implement a timeout scheme, this resets the clock
+   * to prevent the Users session from being timed out.
+   */
+  void touch();
 }

--- a/vertx-auth-common/src/main/resources/vertx-auth-common-js/user.js
+++ b/vertx-auth-common/src/main/resources/vertx-auth-common-js/user.js
@@ -106,6 +106,20 @@ var User = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+   Reset session timeout counter. For AuthProviders that implement a timeout scheme, this resets the clock
+   to prevent the Users session from being timed out.
+
+   @public
+
+   */
+  this.touch = function() {
+    var __args = arguments;
+    if (__args.length === 0) {
+      j_user["touch()"]();
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.

--- a/vertx-auth-common/src/main/resources/vertx-auth-common/user.rb
+++ b/vertx-auth-common/src/main/resources/vertx-auth-common/user.rb
@@ -61,5 +61,14 @@ module VertxAuthCommon
       end
       raise ArgumentError, "Invalid arguments when calling set_auth_provider(authProvider)"
     end
+    #  Reset session timeout counter. For AuthProviders that implement a timeout scheme, this resets the clock
+    #  to prevent the Users session from being timed out.
+    # @return [void]
+    def touch
+      if !block_given?
+        return @j_del.java_method(:touch, []).call()
+      end
+      raise ArgumentError, "Invalid arguments when calling touch()"
+    end
   end
 end

--- a/vertx-auth-jdbc/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/groovy/index.adoc
@@ -13,7 +13,7 @@ add the following dependency to the _dependencies_ section of your build descrip
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-jdbc</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -21,7 +21,7 @@ add the following dependency to the _dependencies_ section of your build descrip
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-jdbc:3.3.2'
+compile 'io.vertx:vertx-auth-jdbc:3.4.0-SNAPSHOT'
 ----
 
 To create an instance you first need an instance of `link:../../groovydoc/io/vertx/groovy/ext/jdbc/JDBCClient.html[JDBCClient]`. To learn how to create one

--- a/vertx-auth-jdbc/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/java/index.adoc
@@ -13,7 +13,7 @@ add the following dependency to the _dependencies_ section of your build descrip
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-jdbc</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -21,7 +21,7 @@ add the following dependency to the _dependencies_ section of your build descrip
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-jdbc:3.3.2'
+compile 'io.vertx:vertx-auth-jdbc:3.4.0-SNAPSHOT'
 ----
 
 To create an instance you first need an instance of `link:../../apidocs/io/vertx/ext/jdbc/JDBCClient.html[JDBCClient]`. To learn how to create one

--- a/vertx-auth-jdbc/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/js/index.adoc
@@ -13,7 +13,7 @@ add the following dependency to the _dependencies_ section of your build descrip
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-jdbc</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -21,7 +21,7 @@ add the following dependency to the _dependencies_ section of your build descrip
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-jdbc:3.3.2'
+compile 'io.vertx:vertx-auth-jdbc:3.4.0-SNAPSHOT'
 ----
 
 To create an instance you first need an instance of `link:../../jsdoc/module-vertx-jdbc-js_jdbc_client-JDBCClient.html[JDBCClient]`. To learn how to create one

--- a/vertx-auth-jdbc/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/ruby/index.adoc
@@ -13,7 +13,7 @@ add the following dependency to the _dependencies_ section of your build descrip
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-jdbc</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -21,7 +21,7 @@ add the following dependency to the _dependencies_ section of your build descrip
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-jdbc:3.3.2'
+compile 'io.vertx:vertx-auth-jdbc:3.4.0-SNAPSHOT'
 ----
 
 To create an instance you first need an instance of `link:../../yardoc/VertxJdbc/JDBCClient.html[JDBCClient]`. To learn how to create one

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCUser.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCUser.java
@@ -75,6 +75,11 @@ public class JDBCUser extends AbstractUser {
   }
 
   @Override
+  public void touch() {
+    //NOOP
+  }
+
+  @Override
   public void writeToBuffer(Buffer buff) {
     super.writeToBuffer(buff);
     byte[] bytes = username.getBytes(StandardCharsets.UTF_8);

--- a/vertx-auth-jwt/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/groovy/index.adoc
@@ -12,7 +12,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-jwt</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-jwt:3.3.2'
+compile 'io.vertx:vertx-auth-jwt:3.4.0-SNAPSHOT'
 ----
 
 JSON Web Token is a simple way to send information in the clear (usually in a URL) whose contents can be

--- a/vertx-auth-jwt/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/java/index.adoc
@@ -12,7 +12,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-jwt</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-jwt:3.3.2'
+compile 'io.vertx:vertx-auth-jwt:3.4.0-SNAPSHOT'
 ----
 
 JSON Web Token is a simple way to send information in the clear (usually in a URL) whose contents can be

--- a/vertx-auth-jwt/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/js/index.adoc
@@ -12,7 +12,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-jwt</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-jwt:3.3.2'
+compile 'io.vertx:vertx-auth-jwt:3.4.0-SNAPSHOT'
 ----
 
 JSON Web Token is a simple way to send information in the clear (usually in a URL) whose contents can be

--- a/vertx-auth-jwt/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/ruby/index.adoc
@@ -12,7 +12,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-jwt</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-jwt:3.3.2'
+compile 'io.vertx:vertx-auth-jwt:3.4.0-SNAPSHOT'
 ----
 
 JSON Web Token is a simple way to send information in the clear (usually in a URL) whose contents can be

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTUser.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTUser.java
@@ -103,4 +103,9 @@ public class JWTUser extends AbstractUser {
 
     return pos;
   }
+
+  @Override
+  public void touch() {
+    //NOOP
+  }
 }

--- a/vertx-auth-mongo/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-mongo/src/main/asciidoc/groovy/index.adoc
@@ -13,7 +13,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-mongo</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -21,7 +21,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-mongo:3.3.2'
+compile 'io.vertx:vertx-auth-mongo:3.4.0-SNAPSHOT'
 ----
 
 To create an instance you first need an instance of `link:../../groovydoc/io/vertx/groovy/ext/mongo/MongoClient.html[MongoClient]`. To learn how to create one

--- a/vertx-auth-mongo/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-mongo/src/main/asciidoc/java/index.adoc
@@ -13,7 +13,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-mongo</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -21,7 +21,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-mongo:3.3.2'
+compile 'io.vertx:vertx-auth-mongo:3.4.0-SNAPSHOT'
 ----
 
 To create an instance you first need an instance of `link:../../apidocs/io/vertx/ext/mongo/MongoClient.html[MongoClient]`. To learn how to create one

--- a/vertx-auth-mongo/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-mongo/src/main/asciidoc/js/index.adoc
@@ -13,7 +13,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-mongo</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -21,7 +21,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-mongo:3.3.2'
+compile 'io.vertx:vertx-auth-mongo:3.4.0-SNAPSHOT'
 ----
 
 To create an instance you first need an instance of `link:../../jsdoc/module-vertx-mongo-js_mongo_client-MongoClient.html[MongoClient]`. To learn how to create one

--- a/vertx-auth-mongo/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-mongo/src/main/asciidoc/ruby/index.adoc
@@ -13,7 +13,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-mongo</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -21,7 +21,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-mongo:3.3.2'
+compile 'io.vertx:vertx-auth-mongo:3.4.0-SNAPSHOT'
 ----
 
 To create an instance you first need an instance of `link:../../yardoc/VertxMongo/MongoClient.html[MongoClient]`. To learn how to create one

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUser.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUser.java
@@ -84,6 +84,7 @@ public class MongoUser extends AbstractUser {
     this.mongoAuth = (MongoAuth) authProvider;
   }
 
+
   /**
    * check wether the current user has the given role
    * 
@@ -136,6 +137,11 @@ public class MongoUser extends AbstractUser {
     } catch (Throwable e) {
       resultHandler.handle(Future.failedFuture(e));
     }
+  }
+
+  @Override
+  public void touch() {
+    //NOOP
   }
 
   @Override

--- a/vertx-auth-oauth2/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/groovy/index.adoc
@@ -12,7 +12,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-oauth2</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-oauth2:3.3.2'
+compile 'io.vertx:vertx-auth-oauth2:3.4.0-SNAPSHOT'
 ----
 
 OAuth2 lets users grant the access to the desired resources to third party applications, giving them the possibility

--- a/vertx-auth-oauth2/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/java/index.adoc
@@ -12,7 +12,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-oauth2</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-oauth2:3.3.2'
+compile 'io.vertx:vertx-auth-oauth2:3.4.0-SNAPSHOT'
 ----
 
 OAuth2 lets users grant the access to the desired resources to third party applications, giving them the possibility

--- a/vertx-auth-oauth2/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/js/index.adoc
@@ -12,7 +12,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-oauth2</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-oauth2:3.3.2'
+compile 'io.vertx:vertx-auth-oauth2:3.4.0-SNAPSHOT'
 ----
 
 OAuth2 lets users grant the access to the desired resources to third party applications, giving them the possibility

--- a/vertx-auth-oauth2/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/ruby/index.adoc
@@ -12,7 +12,7 @@ dependency to the _dependencies_ section of your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-oauth2</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ dependency to the _dependencies_ section of your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-oauth2:3.3.2'
+compile 'io.vertx:vertx-auth-oauth2:3.4.0-SNAPSHOT'
 ----
 
 OAuth2 lets users grant the access to the desired resources to third party applications, giving them the possibility

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/AccessTokenImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/AccessTokenImpl.java
@@ -280,6 +280,11 @@ public class AccessTokenImpl extends AbstractUser implements AccessToken {
   }
 
   @Override
+  public void touch() {
+    //NOOP
+  }
+
+  @Override
   public void writeToBuffer(Buffer buff) {
     super.writeToBuffer(buff);
     byte[] bytes = token.encode().getBytes(StandardCharsets.UTF_8);

--- a/vertx-auth-shiro/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-shiro/src/main/asciidoc/groovy/index.adoc
@@ -12,7 +12,7 @@ project, add the following dependency to the _dependencies_ section of your buil
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-shiro</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ project, add the following dependency to the _dependencies_ section of your buil
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-shiro:3.3.2'
+compile 'io.vertx:vertx-auth-shiro:3.4.0-SNAPSHOT'
 ----
 
 We provide out of the box support for properties and LDAP based auth using Shiro, and you can also plugin in any

--- a/vertx-auth-shiro/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-shiro/src/main/asciidoc/java/index.adoc
@@ -12,7 +12,7 @@ project, add the following dependency to the _dependencies_ section of your buil
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-shiro</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ project, add the following dependency to the _dependencies_ section of your buil
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-shiro:3.3.2'
+compile 'io.vertx:vertx-auth-shiro:3.4.0-SNAPSHOT'
 ----
 
 We provide out of the box support for properties and LDAP based auth using Shiro, and you can also plugin in any

--- a/vertx-auth-shiro/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-shiro/src/main/asciidoc/js/index.adoc
@@ -12,7 +12,7 @@ project, add the following dependency to the _dependencies_ section of your buil
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-shiro</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ project, add the following dependency to the _dependencies_ section of your buil
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-shiro:3.3.2'
+compile 'io.vertx:vertx-auth-shiro:3.4.0-SNAPSHOT'
 ----
 
 We provide out of the box support for properties and LDAP based auth using Shiro, and you can also plugin in any

--- a/vertx-auth-shiro/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-shiro/src/main/asciidoc/ruby/index.adoc
@@ -12,7 +12,7 @@ project, add the following dependency to the _dependencies_ section of your buil
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-shiro</artifactId>
-  <version>3.3.2</version>
+  <version>3.4.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -20,7 +20,7 @@ project, add the following dependency to the _dependencies_ section of your buil
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-shiro:3.3.2'
+compile 'io.vertx:vertx-auth-shiro:3.4.0-SNAPSHOT'
 ----
 
 We provide out of the box support for properties and LDAP based auth using Shiro, and you can also plugin in any

--- a/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/ShiroUser.java
+++ b/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/ShiroUser.java
@@ -23,6 +23,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
+import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.apache.shiro.subject.Subject;
@@ -116,5 +117,17 @@ public class ShiroUser extends AbstractUser {
     } else {
       throw new IllegalArgumentException("Not a ShiroAuthProviderImpl");
     }
+  }
+
+  @Override
+  public void touch() {
+    Session session = subject.getSession(false);
+    if (session != null) {
+      session.touch();
+    }
+  }
+
+  public void setSessionTimeout(long timeout) {
+    subject.getSession().setTimeout(timeout);
   }
 }

--- a/vertx-auth-shiro/src/test/java/io/vertx/ext/auth/test/shiro/CreateShiroAuthProviderTest.java
+++ b/vertx-auth-shiro/src/test/java/io/vertx/ext/auth/test/shiro/CreateShiroAuthProviderTest.java
@@ -20,12 +20,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.shiro.ShiroAuth;
 import io.vertx.test.core.VertxTestBase;
-import org.apache.shiro.authc.AuthenticationException;
-import org.apache.shiro.authc.AuthenticationInfo;
-import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.realm.Realm;
-import org.apache.shiro.subject.PrincipalCollection;
-import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.junit.Test;
 
 /**
@@ -36,7 +31,7 @@ public class CreateShiroAuthProviderTest extends VertxTestBase {
 
   @Test
   public void testCreateWithRealm() {
-    Realm realm = new MyShiroRealm();
+    Realm realm = new TestShiroRealm();
     AuthProvider authProvider = ShiroAuth.create(vertx, realm);
     JsonObject authInfo = new JsonObject().put("username", "tim").put("password", "sausages");
     authProvider.authenticate(authInfo, onSuccess(user -> {
@@ -46,33 +41,5 @@ public class CreateShiroAuthProviderTest extends VertxTestBase {
     await();
   }
 
-  class MyShiroRealm implements Realm {
 
-    @Override
-    public String getName() {
-      return getClass().getName();
-    }
-
-    @Override
-    public boolean supports(AuthenticationToken token) {
-      return true;
-    }
-
-    @Override
-    public AuthenticationInfo getAuthenticationInfo(AuthenticationToken token) throws AuthenticationException {
-
-      return new AuthenticationInfo() {
-        @Override
-        public PrincipalCollection getPrincipals() {
-          return new SimplePrincipalCollection(token.getPrincipal(), getClass().getName());
-        }
-
-        @Override
-        public Object getCredentials() {
-          return token.getCredentials();
-        }
-      };
-    }
-
-  }
 }

--- a/vertx-auth-shiro/src/test/java/io/vertx/ext/auth/test/shiro/ShiroUserTest.java
+++ b/vertx-auth-shiro/src/test/java/io/vertx/ext/auth/test/shiro/ShiroUserTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.auth.test.shiro;
+
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.shiro.impl.ShiroAuthProviderImpl;
+import io.vertx.ext.auth.shiro.impl.ShiroUser;
+import io.vertx.test.core.VertxTestBase;
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.session.ExpiredSessionException;
+import org.junit.Test;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ */
+public class ShiroUserTest extends VertxTestBase {
+
+  private void authenticate(Handler<User> onLoggedIn) {
+    Realm realm = new TestShiroRealm();
+
+    AuthProvider authProvider = new ShiroAuthProviderImpl(vertx, realm);
+    JsonObject authInfo = new JsonObject()
+        .put("username", "tim")
+        .put("password", "sausages");
+
+    authProvider.authenticate(authInfo, onSuccess(user -> {
+      assertNotNull(user);
+      ((ShiroUser) user).setSessionTimeout(10);
+
+      onLoggedIn.handle(user);
+    }));
+  }
+
+  @Test
+  public void userDoesTimeout() {
+    authenticate(user -> {
+      vertx.setTimer(20, IGNORE -> {
+        user.isAuthorised("foo", result -> {
+          assertFalse(result.succeeded());
+          assertTrue(result.cause() instanceof ExpiredSessionException);
+          testComplete();
+        });
+      });
+    });
+    await();
+  }
+
+  @Test
+  public void userDoesNotTimeout() {
+    authenticate(user -> {
+      vertx.setPeriodic(1, IGNORE -> {
+        user.touch();
+      });
+
+      vertx.setTimer(20, IGNORE -> {
+        user.isAuthorised("foo", result -> {
+          assertTrue(result.succeeded());
+          testComplete();
+        });
+      });
+    });
+    await();
+  }
+}

--- a/vertx-auth-shiro/src/test/java/io/vertx/ext/auth/test/shiro/TestShiroRealm.java
+++ b/vertx-auth-shiro/src/test/java/io/vertx/ext/auth/test/shiro/TestShiroRealm.java
@@ -1,0 +1,38 @@
+package io.vertx.ext.auth.test.shiro;
+
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.apache.shiro.subject.SimplePrincipalCollection;
+
+public class TestShiroRealm implements Realm {
+
+  @Override
+  public String getName() {
+    return getClass().getName();
+  }
+
+  @Override
+  public boolean supports(AuthenticationToken token) {
+    return true;
+  }
+
+  @Override
+  public AuthenticationInfo getAuthenticationInfo(AuthenticationToken token) throws AuthenticationException {
+
+    return new AuthenticationInfo() {
+      @Override
+      public PrincipalCollection getPrincipals() {
+        return new SimplePrincipalCollection(token.getPrincipal(), getClass().getName());
+      }
+
+      @Override
+      public Object getCredentials() {
+        return token.getCredentials();
+      }
+    };
+  }
+
+}


### PR DESCRIPTION
Currently the `lastAccessTime` on the `subject.session` (an instance of `SimpleSession`) that is inside the `ShiroUser` object is never updated. This means that all Users will timeout after 30 min even if they are active. There is currently no way to reset the timeout for these users.

This adds `touch` to the `User` interface that allows the user to indicate they are still active. It does unfortunately add a method that is reasonably Shiro specific to the User interface, hence why the other Users touch methods are NOOP. But this seemed about the cleanest way to allow users to indicate they are still active. 
