### PR TITLE
#73 Added support for roles in nested object structure

### DIFF
--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTUser.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTUser.java
@@ -46,7 +46,29 @@ public class JWTUser extends AbstractUser {
 
   public JWTUser(JsonObject jwtToken, String permissionsClaimKey) {
     this.jwtToken = jwtToken;
-    this.permissions = jwtToken.getJsonArray(permissionsClaimKey, null);
+
+    if(permissionsClaimKey.contains("/")) {
+      getNestedJsonValue(jwtToken, permissionsClaimKey);
+    } else {
+      this.permissions = jwtToken.getJsonArray(permissionsClaimKey, null);
+    }
+
+  }
+
+  private void getNestedJsonValue(JsonObject jwtToken, String permissionsClaimKey) {
+    String[] keys = permissionsClaimKey.split("/");
+    JsonObject obj = null;
+    for(int i = 0; i < keys.length; i++) {
+        if(i == 0) {
+          obj = jwtToken.getJsonObject(keys[i]);
+        } else if (i == keys.length -1) {
+          if(obj != null) {
+            this.permissions = obj.getJsonArray(keys[i]);
+          }
+        } else {
+            obj = obj.getJsonObject(keys[i]);
+        }
+    }
   }
 
   @Override

--- a/vertx-auth-jwt/src/test/java/io/vertx/ext/auth/jwt/impl/JWTUserTest.java
+++ b/vertx-auth-jwt/src/test/java/io/vertx/ext/auth/jwt/impl/JWTUserTest.java
@@ -1,0 +1,100 @@
+package io.vertx.ext.auth.jwt.impl;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class JWTUserTest extends VertxTestBase{
+    @Test
+    public void testNormalRoles() {
+        JsonObject token = new JsonObject()
+                        .put("roles", new JsonArray(Arrays.asList("role1", "role2")));
+
+        JWTUser jwtUser = new JWTUser(token, "roles");
+        jwtUser.isAuthorised("role1", r -> {
+            assertTrue("should have role", r.result());
+            testComplete();
+        });
+
+        await();
+    }
+
+    @Test
+    public void testNormalRolesNoAccess() {
+        JsonObject token = new JsonObject()
+                .put("roles", new JsonArray(Arrays.asList("role1", "role2")));
+
+        JWTUser jwtUser = new JWTUser(token, "roles");
+        jwtUser.isAuthorised("role3", r -> {
+            assertFalse("should not have role", r.result());
+            testComplete();
+        });
+
+        await();
+    }
+
+    @Test
+    public void testParseNestedRoles() {
+        JsonObject token = new JsonObject()
+                .put("realm", new JsonObject()
+                        .put("roles", new JsonArray(Arrays.asList("role1", "role2"))));
+
+        JWTUser jwtUser = new JWTUser(token, "realm/roles");
+        jwtUser.isAuthorised("role1", r -> {
+            assertTrue("should have role", r.result());
+            testComplete();
+        });
+
+        await();
+    }
+
+    @Test
+    public void testParseNestedRolesNoAccess() {
+        JsonObject token = new JsonObject()
+                .put("realm", new JsonObject()
+                        .put("roles", new JsonArray(Arrays.asList("role1", "role2"))));
+
+        JWTUser jwtUser = new JWTUser(token, "realm/roles");
+        jwtUser.isAuthorised("role3", r -> {
+            assertFalse("should not have role", r.result());
+            testComplete();
+        });
+
+        await();
+    }
+
+    @Test
+    public void testParseDeeplyNestedRoles() {
+        JsonObject token = new JsonObject()
+                .put("realm", new JsonObject()
+                        .put("access", new JsonObject()
+                        .put("roles", new JsonArray(Arrays.asList("role1", "role2")))));
+
+        JWTUser jwtUser = new JWTUser(token, "realm/access/roles");
+        jwtUser.isAuthorised("role1", r -> {
+            assertTrue("should have role", r.result());
+            testComplete();
+        });
+
+        await();
+    }
+
+    @Test
+    public void testInvalidNestedKey() {
+        JsonObject token = new JsonObject()
+                .put("realm", new JsonObject()
+                        .put("access", new JsonObject()
+                                .put("roles", new JsonArray(Arrays.asList("role1", "role2")))));
+
+        JWTUser jwtUser = new JWTUser(token, "realm/wrong/roles");
+        jwtUser.isAuthorised("role1", r -> {
+            assertFalse("should not have role", r.result());
+            testComplete();
+        });
+
+        await();
+    }
+}


### PR DESCRIPTION
As discussed in #73.

For KeyCloak the following works:

```
JsonObject config = new JsonObject()
                .put("public-key", PUBLIC_KEY)
                .put("permissionsClaimKey", "realm_access/roles");
JWTAuth authProvider = JWTAuth.create(vertx, config);
```
