### PR TITLE
Add helper class for Keycloak

### DIFF
--- a/vertx-auth-oauth2/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/groovy/index.adoc
@@ -450,3 +450,18 @@ oauth2.getToken([
 })
 
 ----
+
+We also provide a helper class for Keycloak so that we can we can easily retrieve decoded token and some necessary
+data (e.g. `preferred_username`) from the Keycloak principal. For example:
+
+[source,groovy]
+----
+import io.vertx.groovy.ext.auth.oauth2.KeycloakHelper
+// you can get the decoded `id_token` from the Keycloak principal
+def idToken = KeycloakHelper.idToken(principal)
+
+// you can also retrieve some properties directly from the Keycloak principal
+// e.g. `preferred_username`
+def username = KeycloakHelper.preferredUsername(principal)
+
+----

--- a/vertx-auth-oauth2/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/java/index.adoc
@@ -375,3 +375,15 @@ oauth2.getToken(new JsonObject().put("username", "user").put("password", "secret
   }
 });
 ----
+
+We also provide a helper class for Keycloak so that we can we can easily retrieve decoded token and some necessary
+data (e.g. `preferred_username`) from the Keycloak principal. For example:
+
+[source,java]
+----
+JsonObject idToken = KeycloakHelper.idToken(principal);
+
+// you can also retrieve some properties directly from the Keycloak principal
+// e.g. `preferred_username`
+String username = KeycloakHelper.preferredUsername(principal);
+----

--- a/vertx-auth-oauth2/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/js/index.adoc
@@ -439,3 +439,18 @@ oauth2.getToken({
 });
 
 ----
+
+We also provide a helper class for Keycloak so that we can we can easily retrieve decoded token and some necessary
+data (e.g. `preferred_username`) from the Keycloak principal. For example:
+
+[source,js]
+----
+var KeycloakHelper = require("vertx-auth-oauth2-js/keycloak_helper");
+// you can get the decoded `id_token` from the Keycloak principal
+var idToken = KeycloakHelper.idToken(principal);
+
+// you can also retrieve some properties directly from the Keycloak principal
+// e.g. `preferred_username`
+var username = KeycloakHelper.preferredUsername(principal);
+
+----

--- a/vertx-auth-oauth2/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/ruby/index.adoc
@@ -439,3 +439,18 @@ oauth2.get_token({
 }
 
 ----
+
+We also provide a helper class for Keycloak so that we can we can easily retrieve decoded token and some necessary
+data (e.g. `preferred_username`) from the Keycloak principal. For example:
+
+[source,ruby]
+----
+require 'vertx-auth-oauth2/keycloak_helper'
+# you can get the decoded `id_token` from the Keycloak principal
+idToken = VertxAuthOauth2::KeycloakHelper.id_token(principal)
+
+# you can also retrieve some properties directly from the Keycloak principal
+# e.g. `preferred_username`
+username = VertxAuthOauth2::KeycloakHelper.preferred_username(principal)
+
+----

--- a/vertx-auth-oauth2/src/main/groovy/io/vertx/groovy/ext/auth/oauth2/KeycloakHelper.groovy
+++ b/vertx-auth-oauth2/src/main/groovy/io/vertx/groovy/ext/auth/oauth2/KeycloakHelper.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.groovy.ext.auth.oauth2;
+
+import groovy.transform.CompileStatic
+import io.vertx.lang.groovy.InternalHelper
+import io.vertx.core.json.JsonObject
+import java.util.Set
+import io.vertx.core.json.JsonObject
+
+/**
+ * Helper class for processing Keycloak principal.
+ */
+@CompileStatic
+public class KeycloakHelper {
+  private final def io.vertx.ext.auth.oauth2.KeycloakHelper delegate;
+
+  public KeycloakHelper(Object delegate) {
+    this.delegate = (io.vertx.ext.auth.oauth2.KeycloakHelper) delegate;
+  }
+
+  public Object getDelegate() {
+    return delegate;
+  }
+  /**
+   * Get raw `id_token` string from the principal.
+   * @param principal user principal
+   * @return the raw id token string
+   */
+  public static String getRawIdToken(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getRawIdToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+  /**
+   * Get decoded `id_token` from the principal.
+   * @param principal user principal
+   * @return the id token
+   */
+  public static Map<String, Object> getIdToken(Map<String, Object> principal) {
+    def ret = (Map<String, Object>) InternalHelper.wrapObject(io.vertx.ext.auth.oauth2.KeycloakHelper.getIdToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null));
+    return ret;
+  }
+  /**
+   * Get raw `access_token` string from the principal.
+   * @param principal user principal
+   * @return the raw access token string
+   */
+  public static String getRawAccessToken(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getRawAccessToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+  /**
+   * Get decoded `access_token` from the principal.
+   * @param principal user principal
+   * @return the access token
+   */
+  public static Map<String, Object> getAccessToken(Map<String, Object> principal) {
+    def ret = (Map<String, Object>) InternalHelper.wrapObject(io.vertx.ext.auth.oauth2.KeycloakHelper.getAccessToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null));
+    return ret;
+  }
+
+  public static int getAuthTime(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getAuthTime(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+
+  public static String getSessionState(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getSessionState(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+
+  public static String getAcr(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getAcr(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+
+  public static String getName(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getName(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+
+  public static String getEmail(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getEmail(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+
+  public static String getPreferredUsername(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getPreferredUsername(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+
+  public static String getNickName(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getNickName(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+
+  public static Set<String> getAllowedOrigins(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getAllowedOrigins(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+    return ret;
+  }
+  /**
+   * Parse the token string with base64 encoder.
+   * This will only obtain the "payload" part of the token.
+   * @param token token string
+   * @return token payload json object
+   */
+  public static Map<String, Object> parseToken(String token) {
+    def ret = (Map<String, Object>) InternalHelper.wrapObject(io.vertx.ext.auth.oauth2.KeycloakHelper.parseToken(token));
+    return ret;
+  }
+}

--- a/vertx-auth-oauth2/src/main/groovy/io/vertx/groovy/ext/auth/oauth2/KeycloakHelper.groovy
+++ b/vertx-auth-oauth2/src/main/groovy/io/vertx/groovy/ext/auth/oauth2/KeycloakHelper.groovy
@@ -41,8 +41,8 @@ public class KeycloakHelper {
    * @param principal user principal
    * @return the raw id token string
    */
-  public static String getRawIdToken(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getRawIdToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static String rawIdToken(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.rawIdToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
   /**
@@ -50,8 +50,8 @@ public class KeycloakHelper {
    * @param principal user principal
    * @return the id token
    */
-  public static Map<String, Object> getIdToken(Map<String, Object> principal) {
-    def ret = (Map<String, Object>) InternalHelper.wrapObject(io.vertx.ext.auth.oauth2.KeycloakHelper.getIdToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null));
+  public static Map<String, Object> idToken(Map<String, Object> principal) {
+    def ret = (Map<String, Object>) InternalHelper.wrapObject(io.vertx.ext.auth.oauth2.KeycloakHelper.idToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null));
     return ret;
   }
   /**
@@ -59,8 +59,8 @@ public class KeycloakHelper {
    * @param principal user principal
    * @return the raw access token string
    */
-  public static String getRawAccessToken(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getRawAccessToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static String rawAccessToken(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.rawAccessToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
   /**
@@ -68,52 +68,52 @@ public class KeycloakHelper {
    * @param principal user principal
    * @return the access token
    */
-  public static Map<String, Object> getAccessToken(Map<String, Object> principal) {
-    def ret = (Map<String, Object>) InternalHelper.wrapObject(io.vertx.ext.auth.oauth2.KeycloakHelper.getAccessToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null));
+  public static Map<String, Object> accessToken(Map<String, Object> principal) {
+    def ret = (Map<String, Object>) InternalHelper.wrapObject(io.vertx.ext.auth.oauth2.KeycloakHelper.accessToken(principal != null ? new io.vertx.core.json.JsonObject(principal) : null));
     return ret;
   }
 
-  public static int getAuthTime(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getAuthTime(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static int authTime(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.authTime(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
 
-  public static String getSessionState(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getSessionState(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static String sessionState(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.sessionState(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
 
-  public static String getAcr(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getAcr(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static String acr(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.acr(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
 
-  public static String getName(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getName(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static String name(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.name(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
 
-  public static String getEmail(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getEmail(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static String email(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.email(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
 
-  public static String getPreferredUsername(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getPreferredUsername(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static String preferredUsername(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.preferredUsername(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
 
-  public static String getNickName(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getNickName(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static String nickName(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.nickName(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
 
-  public static Set<String> getAllowedOrigins(Map<String, Object> principal) {
-    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.getAllowedOrigins(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
+  public static Set<String> allowedOrigins(Map<String, Object> principal) {
+    def ret = io.vertx.ext.auth.oauth2.KeycloakHelper.allowedOrigins(principal != null ? new io.vertx.core.json.JsonObject(principal) : null);
     return ret;
   }
   /**
-   * Parse the token string with base64 encoder.
+   * Parse the token string with base64 decoder.
    * This will only obtain the "payload" part of the token.
    * @param token token string
    * @return token payload json object

--- a/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
+++ b/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
@@ -294,4 +294,13 @@ public class AuthOAuth2Examples {
       }
     });
   }
+
+  public void example14(JsonObject principal) {
+    // you can get the decoded `id_token` from the Keycloak principal
+    JsonObject idToken = KeycloakHelper.idToken(principal);
+
+    // you can also retrieve some properties directly from the Keycloak principal
+    // e.g. `preferred_username`
+    String username = KeycloakHelper.preferredUsername(principal);
+  }
 }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/KeycloakHelper.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/KeycloakHelper.java
@@ -22,7 +22,7 @@ public interface KeycloakHelper {
    * @param principal user principal
    * @return the raw id token string
    */
-  static String getRawIdToken(JsonObject principal) {
+  static String rawIdToken(JsonObject principal) {
     return principal.getString("id_token");
   }
 
@@ -32,8 +32,8 @@ public interface KeycloakHelper {
    * @param principal user principal
    * @return the id token
    */
-  static JsonObject getIdToken(JsonObject principal) {
-    return parseToken(getRawIdToken(principal));
+  static JsonObject idToken(JsonObject principal) {
+    return parseToken(rawIdToken(principal));
   }
 
   /**
@@ -42,7 +42,7 @@ public interface KeycloakHelper {
    * @param principal user principal
    * @return the raw access token string
    */
-  static String getRawAccessToken(JsonObject principal) {
+  static String rawAccessToken(JsonObject principal) {
     return principal.getString("access_token");
   }
 
@@ -52,43 +52,43 @@ public interface KeycloakHelper {
    * @param principal user principal
    * @return the access token
    */
-  static JsonObject getAccessToken(JsonObject principal) {
-    return parseToken(getRawAccessToken(principal));
+  static JsonObject accessToken(JsonObject principal) {
+    return parseToken(rawAccessToken(principal));
   }
 
   // helper methods for getting fields from the principal
 
-  static int getAuthTime(JsonObject principal) {
-    return getIdToken(principal).getInteger("auth_time");
+  static int authTime(JsonObject principal) {
+    return idToken(principal).getInteger("auth_time");
   }
 
-  static String getSessionState(JsonObject principal) {
-    return getIdToken(principal).getString("session_state");
+  static String sessionState(JsonObject principal) {
+    return idToken(principal).getString("session_state");
   }
 
-  static String getAcr(JsonObject principal) {
-    return getIdToken(principal).getString("acr");
+  static String acr(JsonObject principal) {
+    return idToken(principal).getString("acr");
   }
 
-  static String getName(JsonObject principal) {
-    return getIdToken(principal).getString("name");
+  static String name(JsonObject principal) {
+    return idToken(principal).getString("name");
   }
 
-  static String getEmail(JsonObject principal) {
-    return getIdToken(principal).getString("email");
+  static String email(JsonObject principal) {
+    return idToken(principal).getString("email");
   }
 
-  static String getPreferredUsername(JsonObject principal) {
-    return getIdToken(principal).getString("preferred_username");
+  static String preferredUsername(JsonObject principal) {
+    return idToken(principal).getString("preferred_username");
   }
 
-  static String getNickName(JsonObject principal) {
-    return getIdToken(principal).getString("nickname");
+  static String nickName(JsonObject principal) {
+    return idToken(principal).getString("nickname");
   }
 
   @SuppressWarnings("unchecked")
-  static Set<String> getAllowedOrigins(JsonObject principal) {
-    List<String> allowedOrigins = getAccessToken(principal)
+  static Set<String> allowedOrigins(JsonObject principal) {
+    List<String> allowedOrigins = accessToken(principal)
       .getJsonArray("allowed-origins")
       .getList();
     return new HashSet<>(allowedOrigins);

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/KeycloakHelper.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/KeycloakHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
 package io.vertx.ext.auth.oauth2;
 
 import io.vertx.codegen.annotations.VertxGen;

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/KeycloakHelper.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/KeycloakHelper.java
@@ -1,0 +1,143 @@
+package io.vertx.ext.auth.oauth2;
+
+import io.vertx.core.json.JsonObject;
+import sun.misc.BASE64Decoder;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Helper class for processing Keycloak principal.
+ *
+ * @author Eric Zhao
+ */
+public final class KeycloakHelper {
+
+  private KeycloakHelper() {
+  }
+
+  /**
+   * Get raw `id_token` string from the principal.
+   *
+   * @param principal user principal
+   * @return the raw id token string
+   */
+  public static String getRawIdToken(JsonObject principal) {
+    return principal.getString("id_token");
+  }
+
+  /**
+   * Get decoded `id_token` from the principal.
+   *
+   * @param principal user principal
+   * @return the id token
+   */
+  public static JsonObject getIdToken(JsonObject principal) {
+    return parseToken(getRawIdToken(principal));
+  }
+
+  /**
+   * Get raw `access_token` string from the principal.
+   *
+   * @param principal user principal
+   * @return the raw access token string
+   */
+  public static String getRawAccessToken(JsonObject principal) {
+    return principal.getString("access_token");
+  }
+
+  /**
+   * Get decoded `access_token` from the principal.
+   *
+   * @param principal user principal
+   * @return the access token
+   */
+  public static JsonObject getAccessToken(JsonObject principal) {
+    return parseToken(getRawAccessToken(principal));
+  }
+
+  // helper methods for getting fields from the principal
+
+  public static int getAuthTime(JsonObject principal) {
+    return getIdToken(principal).getInteger("auth_time");
+  }
+
+  public static String getSessionState(JsonObject principal) {
+    return getIdToken(principal).getString("session_state");
+  }
+
+  public static String getAcr(JsonObject principal) {
+    return getIdToken(principal).getString("acr");
+  }
+
+  public static String getName(JsonObject principal) {
+    return getIdToken(principal).getString("name");
+  }
+
+  public static String getEmail(JsonObject principal) {
+    return getIdToken(principal).getString("email");
+  }
+
+  public static String getPreferredUsername(JsonObject principal) {
+    return getIdToken(principal).getString("preferred_username");
+  }
+
+  public static String getNickName(JsonObject principal) {
+    return getIdToken(principal).getString("nickname");
+  }
+
+  @SuppressWarnings("unchecked")
+  public static Set<String> getAllowedOrigins(JsonObject principal) {
+    List<String> allowedOrigins = getAccessToken(principal)
+      .getJsonArray("allowed-origins")
+      .getList();
+    return new HashSet<>(allowedOrigins);
+  }
+
+  /**
+   * Parse the token string with base64 encoder.
+   * This will only obtain the "payload" part of the token.
+   *
+   * @param token token string
+   * @return token payload json object
+   */
+  public static JsonObject parseToken(String token) {
+    if (token == null) {
+      return null;
+    }
+    String[] parts = token.split("\\.");
+    if (parts.length < 2 || parts.length > 3) {
+      throw new IllegalArgumentException("Parsing error");
+    }
+    return new JsonObject(decodeBase64(parts[1])); // get "payload" part
+  }
+
+  private static String decodeBase64(String s) {
+    String decoded = null;
+    if (s != null) {
+      s = s.replace('-', '+');
+      s = s.replace('_', '/');
+      switch (s.length() % 4) { // need padding
+        case 0:
+          break;
+        case 2:
+          s += "==";
+          break;
+        case 3:
+          s += "=";
+          break;
+        default:
+          throw new RuntimeException("Illegal string");
+      }
+      BASE64Decoder decoder = new BASE64Decoder();
+      try {
+        byte[] b = decoder.decodeBuffer(s);
+        decoded = new String(b, "UTF-8");
+      } catch (Exception ex) {
+        ex.printStackTrace();
+      }
+    }
+    return decoded;
+  }
+}

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/package-info.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/package-info.java
@@ -193,6 +193,14 @@
  * {@link examples.AuthOAuth2Examples#example13}
  * ----
  *
+ * We also provide a helper class for Keycloak so that we can we can easily retrieve decoded token and some necessary
+ * data (e.g. `preferred_username`) from the Keycloak principal. For example:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.AuthOAuth2Examples#example14}
+ * ----
+ *
  */
 @Document(fileName = "index.adoc")
 @ModuleGen(name = "vertx-auth-oauth2", groupPackage = "io.vertx")

--- a/vertx-auth-oauth2/src/main/resources/vertx-auth-oauth2-js/keycloak_helper.js
+++ b/vertx-auth-oauth2/src/main/resources/vertx-auth-oauth2-js/keycloak_helper.js
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** @module vertx-auth-oauth2-js/keycloak_helper */
+var utils = require('vertx-js/util/utils');
+
+var io = Packages.io;
+var JsonObject = io.vertx.core.json.JsonObject;
+var JKeycloakHelper = io.vertx.ext.auth.oauth2.KeycloakHelper;
+
+/**
+ Helper class for processing Keycloak principal.
+
+ @class
+ */
+var KeycloakHelper = function (j_val) {
+
+  var j_keycloakHelper = j_val;
+  var that = this;
+
+  // A reference to the underlying Java delegate
+  // NOTE! This is an internal API and must not be used in user code.
+  // If you rely on this property your code is likely to break if we change it / remove it without warning.
+  this._jdel = j_keycloakHelper;
+};
+
+/**
+ Get raw `id_token` string from the principal.
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object} user principal
+ @return {string} the raw id token string
+ */
+KeycloakHelper.getRawIdToken = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return JKeycloakHelper["getRawIdToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+ Get decoded `id_token` from the principal.
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object} user principal
+ @return {Object} the id token
+ */
+KeycloakHelper.getIdToken = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return utils.convReturnJson(JKeycloakHelper["getIdToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal)));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+ Get raw `access_token` string from the principal.
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object} user principal
+ @return {string} the raw access token string
+ */
+KeycloakHelper.getRawAccessToken = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return JKeycloakHelper["getRawAccessToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+ Get decoded `access_token` from the principal.
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object} user principal
+ @return {Object} the access token
+ */
+KeycloakHelper.getAccessToken = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return utils.convReturnJson(JKeycloakHelper["getAccessToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal)));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object}
+ @return {number}
+ */
+KeycloakHelper.getAuthTime = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return JKeycloakHelper["getAuthTime(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object}
+ @return {string}
+ */
+KeycloakHelper.getSessionState = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return JKeycloakHelper["getSessionState(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object}
+ @return {string}
+ */
+KeycloakHelper.getAcr = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return JKeycloakHelper["getAcr(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object}
+ @return {string}
+ */
+KeycloakHelper.getName = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return JKeycloakHelper["getName(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object}
+ @return {string}
+ */
+KeycloakHelper.getEmail = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return JKeycloakHelper["getEmail(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object}
+ @return {string}
+ */
+KeycloakHelper.getPreferredUsername = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return JKeycloakHelper["getPreferredUsername(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object}
+ @return {string}
+ */
+KeycloakHelper.getNickName = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return JKeycloakHelper["getNickName(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param principal {Object}
+ @return {Array.<string>}
+ */
+KeycloakHelper.getAllowedOrigins = function (principal) {
+  var __args = arguments;
+  if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
+    return utils.convReturnSet(JKeycloakHelper["getAllowedOrigins(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal)));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+ Parse the token string with base64 encoder.
+ This will only obtain the "payload" part of the token.
+
+ @memberof module:vertx-auth-oauth2-js/keycloak_helper
+ @param token {string} token string
+ @return {Object} token payload json object
+ */
+KeycloakHelper.parseToken = function (token) {
+  var __args = arguments;
+  if (__args.length === 1 && typeof __args[0] === 'string') {
+    return utils.convReturnJson(JKeycloakHelper["parseToken(java.lang.String)"](token));
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+// We export the Constructor function
+module.exports = KeycloakHelper;

--- a/vertx-auth-oauth2/src/main/resources/vertx-auth-oauth2-js/keycloak_helper.js
+++ b/vertx-auth-oauth2/src/main/resources/vertx-auth-oauth2-js/keycloak_helper.js
@@ -44,10 +44,10 @@ var KeycloakHelper = function (j_val) {
  @param principal {Object} user principal
  @return {string} the raw id token string
  */
-KeycloakHelper.getRawIdToken = function (principal) {
+KeycloakHelper.rawIdToken = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return JKeycloakHelper["getRawIdToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+    return JKeycloakHelper["rawIdToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -58,10 +58,10 @@ KeycloakHelper.getRawIdToken = function (principal) {
  @param principal {Object} user principal
  @return {Object} the id token
  */
-KeycloakHelper.getIdToken = function (principal) {
+KeycloakHelper.idToken = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return utils.convReturnJson(JKeycloakHelper["getIdToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal)));
+    return utils.convReturnJson(JKeycloakHelper["idToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal)));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -72,10 +72,10 @@ KeycloakHelper.getIdToken = function (principal) {
  @param principal {Object} user principal
  @return {string} the raw access token string
  */
-KeycloakHelper.getRawAccessToken = function (principal) {
+KeycloakHelper.rawAccessToken = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return JKeycloakHelper["getRawAccessToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+    return JKeycloakHelper["rawAccessToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -86,10 +86,10 @@ KeycloakHelper.getRawAccessToken = function (principal) {
  @param principal {Object} user principal
  @return {Object} the access token
  */
-KeycloakHelper.getAccessToken = function (principal) {
+KeycloakHelper.accessToken = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return utils.convReturnJson(JKeycloakHelper["getAccessToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal)));
+    return utils.convReturnJson(JKeycloakHelper["accessToken(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal)));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -99,10 +99,10 @@ KeycloakHelper.getAccessToken = function (principal) {
  @param principal {Object}
  @return {number}
  */
-KeycloakHelper.getAuthTime = function (principal) {
+KeycloakHelper.authTime = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return JKeycloakHelper["getAuthTime(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+    return JKeycloakHelper["authTime(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -112,10 +112,10 @@ KeycloakHelper.getAuthTime = function (principal) {
  @param principal {Object}
  @return {string}
  */
-KeycloakHelper.getSessionState = function (principal) {
+KeycloakHelper.sessionState = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return JKeycloakHelper["getSessionState(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+    return JKeycloakHelper["sessionState(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -125,10 +125,10 @@ KeycloakHelper.getSessionState = function (principal) {
  @param principal {Object}
  @return {string}
  */
-KeycloakHelper.getAcr = function (principal) {
+KeycloakHelper.acr = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return JKeycloakHelper["getAcr(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+    return JKeycloakHelper["acr(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -138,10 +138,10 @@ KeycloakHelper.getAcr = function (principal) {
  @param principal {Object}
  @return {string}
  */
-KeycloakHelper.getName = function (principal) {
+KeycloakHelper.name = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return JKeycloakHelper["getName(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+    return JKeycloakHelper["name(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -151,10 +151,10 @@ KeycloakHelper.getName = function (principal) {
  @param principal {Object}
  @return {string}
  */
-KeycloakHelper.getEmail = function (principal) {
+KeycloakHelper.email = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return JKeycloakHelper["getEmail(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+    return JKeycloakHelper["email(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -164,10 +164,10 @@ KeycloakHelper.getEmail = function (principal) {
  @param principal {Object}
  @return {string}
  */
-KeycloakHelper.getPreferredUsername = function (principal) {
+KeycloakHelper.preferredUsername = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return JKeycloakHelper["getPreferredUsername(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+    return JKeycloakHelper["preferredUsername(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -177,10 +177,10 @@ KeycloakHelper.getPreferredUsername = function (principal) {
  @param principal {Object}
  @return {string}
  */
-KeycloakHelper.getNickName = function (principal) {
+KeycloakHelper.nickName = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return JKeycloakHelper["getNickName(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
+    return JKeycloakHelper["nickName(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
@@ -190,15 +190,15 @@ KeycloakHelper.getNickName = function (principal) {
  @param principal {Object}
  @return {Array.<string>}
  */
-KeycloakHelper.getAllowedOrigins = function (principal) {
+KeycloakHelper.allowedOrigins = function (principal) {
   var __args = arguments;
   if (__args.length === 1 && (typeof __args[0] === 'object' && __args[0] != null)) {
-    return utils.convReturnSet(JKeycloakHelper["getAllowedOrigins(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal)));
+    return utils.convReturnSet(JKeycloakHelper["allowedOrigins(io.vertx.core.json.JsonObject)"](utils.convParamJsonObject(principal)));
   } else throw new TypeError('function invoked with invalid arguments');
 };
 
 /**
- Parse the token string with base64 encoder.
+ Parse the token string with base64 decoder.
  This will only obtain the "payload" part of the token.
 
  @memberof module:vertx-auth-oauth2-js/keycloak_helper

--- a/vertx-auth-oauth2/src/main/resources/vertx-auth-oauth2/keycloak_helper.rb
+++ b/vertx-auth-oauth2/src/main/resources/vertx-auth-oauth2/keycloak_helper.rb
@@ -18,116 +18,116 @@ module VertxAuthOauth2
     #  Get raw `id_token` string from the principal.
     # @param [Hash{String => Object}] principal user principal
     # @return [String] the raw id token string
-    def self.get_raw_id_token(principal=nil)
+    def self.raw_id_token(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getRawIdToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:rawIdToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
       end
-      raise ArgumentError, "Invalid arguments when calling get_raw_id_token(principal)"
+      raise ArgumentError, "Invalid arguments when calling raw_id_token(principal)"
     end
 
     #  Get decoded `id_token` from the principal.
     # @param [Hash{String => Object}] principal user principal
     # @return [Hash{String => Object}] the id token
-    def self.get_id_token(principal=nil)
+    def self.id_token(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getIdToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)) != nil ? JSON.parse(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getIdToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)).encode) : nil
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:idToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)) != nil ? JSON.parse(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:idToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)).encode) : nil
       end
-      raise ArgumentError, "Invalid arguments when calling get_id_token(principal)"
+      raise ArgumentError, "Invalid arguments when calling id_token(principal)"
     end
 
     #  Get raw `access_token` string from the principal.
     # @param [Hash{String => Object}] principal user principal
     # @return [String] the raw access token string
-    def self.get_raw_access_token(principal=nil)
+    def self.raw_access_token(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getRawAccessToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:rawAccessToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
       end
-      raise ArgumentError, "Invalid arguments when calling get_raw_access_token(principal)"
+      raise ArgumentError, "Invalid arguments when calling raw_access_token(principal)"
     end
 
     #  Get decoded `access_token` from the principal.
     # @param [Hash{String => Object}] principal user principal
     # @return [Hash{String => Object}] the access token
-    def self.get_access_token(principal=nil)
+    def self.access_token(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAccessToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)) != nil ? JSON.parse(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAccessToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)).encode) : nil
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:accessToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)) != nil ? JSON.parse(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:accessToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)).encode) : nil
       end
-      raise ArgumentError, "Invalid arguments when calling get_access_token(principal)"
+      raise ArgumentError, "Invalid arguments when calling access_token(principal)"
     end
 
     # @param [Hash{String => Object}] principal
     # @return [Fixnum]
-    def self.get_auth_time(principal=nil)
+    def self.auth_time(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAuthTime, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:authTime, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
       end
-      raise ArgumentError, "Invalid arguments when calling get_auth_time(principal)"
+      raise ArgumentError, "Invalid arguments when calling auth_time(principal)"
     end
 
     # @param [Hash{String => Object}] principal
     # @return [String]
-    def self.get_session_state(principal=nil)
+    def self.session_state(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getSessionState, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:sessionState, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
       end
-      raise ArgumentError, "Invalid arguments when calling get_session_state(principal)"
+      raise ArgumentError, "Invalid arguments when calling session_state(principal)"
     end
 
     # @param [Hash{String => Object}] principal
     # @return [String]
-    def self.get_acr(principal=nil)
+    def self.acr(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAcr, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:acr, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
       end
-      raise ArgumentError, "Invalid arguments when calling get_acr(principal)"
+      raise ArgumentError, "Invalid arguments when calling acr(principal)"
     end
 
     # @param [Hash{String => Object}] principal
     # @return [String]
-    def self.get_name(principal=nil)
+    def self.name(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getName, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:name, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
       end
-      raise ArgumentError, "Invalid arguments when calling get_name(principal)"
+      raise ArgumentError, "Invalid arguments when calling name(principal)"
     end
 
     # @param [Hash{String => Object}] principal
     # @return [String]
-    def self.get_email(principal=nil)
+    def self.email(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getEmail, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:email, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
       end
-      raise ArgumentError, "Invalid arguments when calling get_email(principal)"
+      raise ArgumentError, "Invalid arguments when calling email(principal)"
     end
 
     # @param [Hash{String => Object}] principal
     # @return [String]
-    def self.get_preferred_username(principal=nil)
+    def self.preferred_username(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getPreferredUsername, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:preferredUsername, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
       end
-      raise ArgumentError, "Invalid arguments when calling get_preferred_username(principal)"
+      raise ArgumentError, "Invalid arguments when calling preferred_username(principal)"
     end
 
     # @param [Hash{String => Object}] principal
     # @return [String]
-    def self.get_nick_name(principal=nil)
+    def self.nick_name(principal=nil)
       if principal.class == Hash && !block_given?
-        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getNickName, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:nickName, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
       end
-      raise ArgumentError, "Invalid arguments when calling get_nick_name(principal)"
+      raise ArgumentError, "Invalid arguments when calling nick_name(principal)"
     end
 
     # @param [Hash{String => Object}] principal
     # @return [Set<String>]
-    def self.get_allowed_origins(principal=nil)
+    def self.allowed_origins(principal=nil)
       if principal.class == Hash && !block_given?
-        return ::Vertx::Util::Utils.to_set(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAllowedOrigins, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))).map! { |elt| elt }
+        return ::Vertx::Util::Utils.to_set(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:allowedOrigins, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))).map! { |elt| elt }
       end
-      raise ArgumentError, "Invalid arguments when calling get_allowed_origins(principal)"
+      raise ArgumentError, "Invalid arguments when calling allowed_origins(principal)"
     end
 
-    #  Parse the token string with base64 encoder.
+    #  Parse the token string with base64 decoder.
     #  This will only obtain the "payload" part of the token.
     # @param [String] token token string
     # @return [Hash{String => Object}] token payload json object

--- a/vertx-auth-oauth2/src/main/resources/vertx-auth-oauth2/keycloak_helper.rb
+++ b/vertx-auth-oauth2/src/main/resources/vertx-auth-oauth2/keycloak_helper.rb
@@ -1,0 +1,141 @@
+require 'vertx/util/utils.rb'
+# Generated from io.vertx.ext.auth.oauth2.KeycloakHelper
+module VertxAuthOauth2
+  #  Helper class for processing Keycloak principal.
+  class KeycloakHelper
+    # @private
+    # @param j_del [::VertxAuthOauth2::KeycloakHelper] the java delegate
+    def initialize(j_del)
+      @j_del = j_del
+    end
+
+    # @private
+    # @return [::VertxAuthOauth2::KeycloakHelper] the underlying java delegate
+    def j_del
+      @j_del
+    end
+
+    #  Get raw `id_token` string from the principal.
+    # @param [Hash{String => Object}] principal user principal
+    # @return [String] the raw id token string
+    def self.get_raw_id_token(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getRawIdToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+      end
+      raise ArgumentError, "Invalid arguments when calling get_raw_id_token(principal)"
+    end
+
+    #  Get decoded `id_token` from the principal.
+    # @param [Hash{String => Object}] principal user principal
+    # @return [Hash{String => Object}] the id token
+    def self.get_id_token(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getIdToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)) != nil ? JSON.parse(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getIdToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)).encode) : nil
+      end
+      raise ArgumentError, "Invalid arguments when calling get_id_token(principal)"
+    end
+
+    #  Get raw `access_token` string from the principal.
+    # @param [Hash{String => Object}] principal user principal
+    # @return [String] the raw access token string
+    def self.get_raw_access_token(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getRawAccessToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+      end
+      raise ArgumentError, "Invalid arguments when calling get_raw_access_token(principal)"
+    end
+
+    #  Get decoded `access_token` from the principal.
+    # @param [Hash{String => Object}] principal user principal
+    # @return [Hash{String => Object}] the access token
+    def self.get_access_token(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAccessToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)) != nil ? JSON.parse(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAccessToken, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal)).encode) : nil
+      end
+      raise ArgumentError, "Invalid arguments when calling get_access_token(principal)"
+    end
+
+    # @param [Hash{String => Object}] principal
+    # @return [Fixnum]
+    def self.get_auth_time(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAuthTime, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+      end
+      raise ArgumentError, "Invalid arguments when calling get_auth_time(principal)"
+    end
+
+    # @param [Hash{String => Object}] principal
+    # @return [String]
+    def self.get_session_state(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getSessionState, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+      end
+      raise ArgumentError, "Invalid arguments when calling get_session_state(principal)"
+    end
+
+    # @param [Hash{String => Object}] principal
+    # @return [String]
+    def self.get_acr(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAcr, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+      end
+      raise ArgumentError, "Invalid arguments when calling get_acr(principal)"
+    end
+
+    # @param [Hash{String => Object}] principal
+    # @return [String]
+    def self.get_name(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getName, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+      end
+      raise ArgumentError, "Invalid arguments when calling get_name(principal)"
+    end
+
+    # @param [Hash{String => Object}] principal
+    # @return [String]
+    def self.get_email(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getEmail, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+      end
+      raise ArgumentError, "Invalid arguments when calling get_email(principal)"
+    end
+
+    # @param [Hash{String => Object}] principal
+    # @return [String]
+    def self.get_preferred_username(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getPreferredUsername, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+      end
+      raise ArgumentError, "Invalid arguments when calling get_preferred_username(principal)"
+    end
+
+    # @param [Hash{String => Object}] principal
+    # @return [String]
+    def self.get_nick_name(principal=nil)
+      if principal.class == Hash && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getNickName, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))
+      end
+      raise ArgumentError, "Invalid arguments when calling get_nick_name(principal)"
+    end
+
+    # @param [Hash{String => Object}] principal
+    # @return [Set<String>]
+    def self.get_allowed_origins(principal=nil)
+      if principal.class == Hash && !block_given?
+        return ::Vertx::Util::Utils.to_set(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:getAllowedOrigins, [Java::IoVertxCoreJson::JsonObject.java_class]).call(::Vertx::Util::Utils.to_json_object(principal))).map! { |elt| elt }
+      end
+      raise ArgumentError, "Invalid arguments when calling get_allowed_origins(principal)"
+    end
+
+    #  Parse the token string with base64 encoder.
+    #  This will only obtain the "payload" part of the token.
+    # @param [String] token token string
+    # @return [Hash{String => Object}] token payload json object
+    def self.parse_token(token=nil)
+      if token.class == String && !block_given?
+        return Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:parseToken, [Java::java.lang.String.java_class]).call(token) != nil ? JSON.parse(Java::IoVertxExtAuthOauth2::KeycloakHelper.java_method(:parseToken, [Java::java.lang.String.java_class]).call(token).encode) : nil
+      end
+      raise ArgumentError, "Invalid arguments when calling parse_token(token)"
+    end
+  end
+end


### PR DESCRIPTION
Add a helper class for Keycloak so that we can easily retrieve decoded token and some necessary data (e.g. `preferred_username`) from the Keycloak principal.

Signed-off-by: sczyh30 sczyh16@gmail.com
