### PR TITLE
Use getEncoder instead of getUrlEncoder

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
@@ -67,7 +67,7 @@ public class OAuth2API {
       params.remove("access_token");
     } else if (config.isUseBasicAuthorizationHeader() && config.getClientID() != null && !params.containsKey("client_id")) {
       String basic = config.getClientID() + ":" + config.getClientSecret();
-      headers.put("Authorization", "Basic " + Base64.getUrlEncoder().encodeToString(basic.getBytes()));
+      headers.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes()));
     }
 
     JsonObject tmp = config.getHeaders();


### PR DESCRIPTION
According to RFC7617 I don't believe we need to encode special character before doing base64 encoding.

I had an issue with some credentials that contained '$' in them producing a different output with `Base64.getEncoder()`. My OAuth provider didn't accept the authorisation header with `Base64.getUrlEncoder()` but it worked with `Base64.getEncoder()`
