### PR TITLE
Context secure PRNG + docs

### DIFF
--- a/vertx-auth-common/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-common/src/main/asciidoc/groovy/index.adoc
@@ -14,7 +14,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-common</artifactId>
-  <version>3.4.1</version>
+  <version>3.4.2-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -22,7 +22,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-common:3.4.1'
+compile 'io.vertx:vertx-auth-common:3.4.2-SNAPSHOT'
 ----
 
 == Basic concepts
@@ -63,7 +63,7 @@ user and contains operations which allow the user to be authorised.
 
 Here's an example of authenticating a user using a simple username/password implementation:
 
-[source,java]
+[source,groovy]
 ----
 
 def authInfo = [
@@ -95,7 +95,7 @@ The results of all the above are provided asynchronously in the handler.
 
 Here's an example of authorising a user:
 
-[source,java]
+[source,groovy]
 ----
 
 user.isAuthorised("printers:printer1234", { res ->
@@ -145,7 +145,7 @@ If you wish your user objects to be clusterable you should make sure they implem
 
 == Pseudo Random Number Generator
 
-Since Secure Random from java can block during the aquisition of entropy from the system, we provide a simple wrapper
+Since Secure Random from java can block during the acquisition of entropy from the system, we provide a simple wrapper
 around it that can be used without the danger of blocking the event loop.
 
 By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
@@ -157,4 +157,22 @@ every 5 minutes with 64bits of new entropy. However this can all be configured u
 
 Most users should not need to configure these values unless if you notice that the performance of your application is
 being affected by the PRNG algorithm.
+
+=== Sharing Pseudo Random Number Generator
+
+Since the Pseudo Random Number Generator objects are expensive in resources, they consume system entropy which is a
+scarce resource it can be wise to share the PRNG's across all your handlers. In order to do this and to make this
+available to all languages supported by Vert.x you should look into the `link:../../apidocs/io/vertx/ext/auth/VertxContextPRNG.html[VertxContextPRNG]`.
+
+This interface relaxes the lifecycle management of PRNG's for the end user and ensures it can be reused across all
+your application, for example:
+
+[source,groovy]
+----
+// Generate a secure token of 32 bytes as a base64 string
+def token = VertxContextPRNG.current(vertx).nextString(32)
+// Generate a secure random integer
+def randomInt = VertxContextPRNG.current(vertx).nextInt()
+
+----
 <a href="mailto:julien@julienviet.com">Julien Viet</a><a href="http://tfox.org">Tim Fox</a>

--- a/vertx-auth-common/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-common/src/main/asciidoc/java/index.adoc
@@ -14,7 +14,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-common</artifactId>
-  <version>3.4.1</version>
+  <version>3.4.2-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -22,7 +22,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-common:3.4.1'
+compile 'io.vertx:vertx-auth-common:3.4.2-SNAPSHOT'
 ----
 
 == Basic concepts
@@ -138,7 +138,7 @@ If you wish your user objects to be clusterable you should make sure they implem
 
 == Pseudo Random Number Generator
 
-Since Secure Random from java can block during the aquisition of entropy from the system, we provide a simple wrapper
+Since Secure Random from java can block during the acquisition of entropy from the system, we provide a simple wrapper
 around it that can be used without the danger of blocking the event loop.
 
 By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
@@ -150,4 +150,20 @@ every 5 minutes with 64bits of new entropy. However this can all be configured u
 
 Most users should not need to configure these values unless if you notice that the performance of your application is
 being affected by the PRNG algorithm.
+
+=== Sharing Pseudo Random Number Generator
+
+Since the Pseudo Random Number Generator objects are expensive in resources, they consume system entropy which is a
+scarce resource it can be wise to share the PRNG's across all your handlers. In order to do this and to make this
+available to all languages supported by Vert.x you should look into the `link:../../apidocs/io/vertx/ext/auth/VertxContextPRNG.html[VertxContextPRNG]`.
+
+This interface relaxes the lifecycle management of PRNG's for the end user and ensures it can be reused across all
+your application, for example:
+
+[source,java]
+----
+String token = VertxContextPRNG.current(vertx).nextString(32);
+// Generate a secure random integer
+int randomInt = VertxContextPRNG.current(vertx).nextInt();
+----
 <a href="mailto:julien@julienviet.com">Julien Viet</a><a href="http://tfox.org">Tim Fox</a>

--- a/vertx-auth-common/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-common/src/main/asciidoc/js/index.adoc
@@ -14,7 +14,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-common</artifactId>
-  <version>3.4.1</version>
+  <version>3.4.2-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -22,7 +22,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-common:3.4.1'
+compile 'io.vertx:vertx-auth-common:3.4.2-SNAPSHOT'
 ----
 
 == Basic concepts
@@ -63,7 +63,7 @@ user and contains operations which allow the user to be authorised.
 
 Here's an example of authenticating a user using a simple username/password implementation:
 
-[source,java]
+[source,js]
 ----
 
 var authInfo = {
@@ -95,7 +95,7 @@ The results of all the above are provided asynchronously in the handler.
 
 Here's an example of authorising a user:
 
-[source,java]
+[source,js]
 ----
 
 user.isAuthorised("printers:printer1234", function (res, res_err) {
@@ -145,7 +145,7 @@ If you wish your user objects to be clusterable you should make sure they implem
 
 == Pseudo Random Number Generator
 
-Since Secure Random from java can block during the aquisition of entropy from the system, we provide a simple wrapper
+Since Secure Random from java can block during the acquisition of entropy from the system, we provide a simple wrapper
 around it that can be used without the danger of blocking the event loop.
 
 By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
@@ -157,4 +157,23 @@ every 5 minutes with 64bits of new entropy. However this can all be configured u
 
 Most users should not need to configure these values unless if you notice that the performance of your application is
 being affected by the PRNG algorithm.
+
+=== Sharing Pseudo Random Number Generator
+
+Since the Pseudo Random Number Generator objects are expensive in resources, they consume system entropy which is a
+scarce resource it can be wise to share the PRNG's across all your handlers. In order to do this and to make this
+available to all languages supported by Vert.x you should look into the `link:../../jsdoc/module-vertx-auth-common-js_vertx_context_prng-VertxContextPRNG.html[VertxContextPRNG]`.
+
+This interface relaxes the lifecycle management of PRNG's for the end user and ensures it can be reused across all
+your application, for example:
+
+[source,js]
+----
+var VertxContextPRNG = require("vertx-auth-common-js/vertx_context_prng");
+// Generate a secure token of 32 bytes as a base64 string
+var token = VertxContextPRNG.current(vertx).nextString(32);
+// Generate a secure random integer
+var randomInt = VertxContextPRNG.current(vertx).nextInt();
+
+----
 <a href="mailto:julien@julienviet.com">Julien Viet</a><a href="http://tfox.org">Tim Fox</a>

--- a/vertx-auth-common/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-auth-common/src/main/asciidoc/kotlin/index.adoc
@@ -14,7 +14,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-common</artifactId>
-  <version>3.4.1</version>
+  <version>3.4.2-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -22,7 +22,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-common:3.4.1'
+compile 'io.vertx:vertx-auth-common:3.4.2-SNAPSHOT'
 ----
 
 == Basic concepts
@@ -63,7 +63,7 @@ user and contains operations which allow the user to be authorised.
 
 Here's an example of authenticating a user using a simple username/password implementation:
 
-[source,java]
+[source,kotlin]
 ----
 
 var authInfo = json {
@@ -97,7 +97,7 @@ The results of all the above are provided asynchronously in the handler.
 
 Here's an example of authorising a user:
 
-[source,java]
+[source,kotlin]
 ----
 
 user.isAuthorised("printers:printer1234", { res ->
@@ -147,7 +147,7 @@ If you wish your user objects to be clusterable you should make sure they implem
 
 == Pseudo Random Number Generator
 
-Since Secure Random from java can block during the aquisition of entropy from the system, we provide a simple wrapper
+Since Secure Random from java can block during the acquisition of entropy from the system, we provide a simple wrapper
 around it that can be used without the danger of blocking the event loop.
 
 By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
@@ -159,4 +159,22 @@ every 5 minutes with 64bits of new entropy. However this can all be configured u
 
 Most users should not need to configure these values unless if you notice that the performance of your application is
 being affected by the PRNG algorithm.
+
+=== Sharing Pseudo Random Number Generator
+
+Since the Pseudo Random Number Generator objects are expensive in resources, they consume system entropy which is a
+scarce resource it can be wise to share the PRNG's across all your handlers. In order to do this and to make this
+available to all languages supported by Vert.x you should look into the `link:../../apidocs/io/vertx/ext/auth/VertxContextPRNG.html[VertxContextPRNG]`.
+
+This interface relaxes the lifecycle management of PRNG's for the end user and ensures it can be reused across all
+your application, for example:
+
+[source,kotlin]
+----
+// Generate a secure token of 32 bytes as a base64 string
+var token = VertxContextPRNG.current(vertx).nextString(32)
+// Generate a secure random integer
+var randomInt = VertxContextPRNG.current(vertx).nextInt()
+
+----
 <a href="mailto:julien@julienviet.com">Julien Viet</a><a href="http://tfox.org">Tim Fox</a>

--- a/vertx-auth-common/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-common/src/main/asciidoc/ruby/index.adoc
@@ -14,7 +14,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-auth-common</artifactId>
-  <version>3.4.1</version>
+  <version>3.4.2-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -22,7 +22,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-auth-common:3.4.1'
+compile 'io.vertx:vertx-auth-common:3.4.2-SNAPSHOT'
 ----
 
 == Basic concepts
@@ -63,7 +63,7 @@ user and contains operations which allow the user to be authorised.
 
 Here's an example of authenticating a user using a simple username/password implementation:
 
-[source,java]
+[source,ruby]
 ----
 
 authInfo = {
@@ -95,7 +95,7 @@ The results of all the above are provided asynchronously in the handler.
 
 Here's an example of authorising a user:
 
-[source,java]
+[source,ruby]
 ----
 
 user.is_authorised("printers:printer1234") { |res_err,res|
@@ -145,7 +145,7 @@ If you wish your user objects to be clusterable you should make sure they implem
 
 == Pseudo Random Number Generator
 
-Since Secure Random from java can block during the aquisition of entropy from the system, we provide a simple wrapper
+Since Secure Random from java can block during the acquisition of entropy from the system, we provide a simple wrapper
 around it that can be used without the danger of blocking the event loop.
 
 By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
@@ -157,4 +157,23 @@ every 5 minutes with 64bits of new entropy. However this can all be configured u
 
 Most users should not need to configure these values unless if you notice that the performance of your application is
 being affected by the PRNG algorithm.
+
+=== Sharing Pseudo Random Number Generator
+
+Since the Pseudo Random Number Generator objects are expensive in resources, they consume system entropy which is a
+scarce resource it can be wise to share the PRNG's across all your handlers. In order to do this and to make this
+available to all languages supported by Vert.x you should look into the `link:../../yardoc/VertxAuthCommon/VertxContextPRNG.html[VertxContextPRNG]`.
+
+This interface relaxes the lifecycle management of PRNG's for the end user and ensures it can be reused across all
+your application, for example:
+
+[source,ruby]
+----
+require 'vertx-auth-common/vertx_context_prng'
+# Generate a secure token of 32 bytes as a base64 string
+token = VertxAuthCommon::VertxContextPRNG.current(vertx).next_string(32)
+# Generate a secure random integer
+randomInt = VertxAuthCommon::VertxContextPRNG.current(vertx).next_int()
+
+----
 <a href="mailto:julien@julienviet.com">Julien Viet</a><a href="http://tfox.org">Tim Fox</a>

--- a/vertx-auth-common/src/main/java/examples/AuthCommonExamples.java
+++ b/vertx-auth-common/src/main/java/examples/AuthCommonExamples.java
@@ -17,10 +17,11 @@
 package examples;
 
 import io.vertx.core.Context;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.VertxContextRandom;
+import io.vertx.ext.auth.VertxContextPRNG;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -82,8 +83,10 @@ public class AuthCommonExamples {
     });
   }
 
-  public void example4(Context context) {
+  public void example4(Vertx vertx) {
     // Generate a secure token of 32 bytes as a base64 string
-    String token = VertxContextRandom.current(context).nextString(32);
+    String token = VertxContextPRNG.current(vertx).nextString(32);
+    // Generate a secure random integer
+    int randomInt = VertxContextPRNG.current(vertx).nextInt();
   }
 }

--- a/vertx-auth-common/src/main/java/examples/AuthCommonExamples.java
+++ b/vertx-auth-common/src/main/java/examples/AuthCommonExamples.java
@@ -16,7 +16,7 @@
 
 package examples;
 
-import io.vertx.core.Vertx;
+import io.vertx.core.Context;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.User;
@@ -82,8 +82,8 @@ public class AuthCommonExamples {
     });
   }
 
-  public void example4(Vertx vertx) {
+  public void example4(Context context) {
     // Generate a secure token of 32 bytes as a base64 string
-    String token = VertxContextRandom.current(vertx).nextString(32);
+    String token = VertxContextRandom.current(context).nextString(32);
   }
 }

--- a/vertx-auth-common/src/main/java/examples/AuthCommonExamples.java
+++ b/vertx-auth-common/src/main/java/examples/AuthCommonExamples.java
@@ -16,9 +16,11 @@
 
 package examples;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.VertxContextRandom;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -80,5 +82,8 @@ public class AuthCommonExamples {
     });
   }
 
-
+  public void example4(Vertx vertx) {
+    // Generate a secure token of 32 bytes as a base64 string
+    String token = VertxContextRandom.current(vertx).nextString(32);
+  }
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/PRNG.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/PRNG.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author Paulo Lopes
  */
-public class PRNG implements VertxContextRandom {
+public class PRNG implements VertxContextPRNG {
 
   private static final int DEFAULT_SEED_INTERVAL_MILLIS = 300000;
   private static final int DEFAULT_SEED_BITS = 64;

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/PRNG.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/PRNG.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * @author Paulo Lopes
  */
-public class PRNG {
+public class PRNG implements VertxContextRandom {
 
   private static final int DEFAULT_SEED_INTERVAL_MILLIS = 300000;
   private static final int DEFAULT_SEED_BITS = 64;
@@ -96,8 +96,18 @@ public class PRNG {
     }
   }
 
+  @Override
   public void nextBytes(byte[] bytes) {
-    random.nextBytes(bytes);
+    if (bytes != null) {
+      random.nextBytes(bytes);
+      dirty = true;
+    }
+  }
+
+  @Override
+  public int nextInt() {
+    final int rand = random.nextInt();
     dirty = true;
+    return rand;
   }
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextRandom.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextRandom.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.auth;
+
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+import java.util.Base64;
+
+/**
+ *
+ * A secure non blocking random number generator isolated to the current context. The PRNG is bound to the vert.x
+ * context and setup to close when the context shuts down.
+ *
+ * When applicable, use of VertxContextRandom rather than create new PRNG objects is helpful to keep the system entropy
+ * usage to the minimum avoiding potential blocking across the application.
+ *
+ * The use of VertxContextRandom is particularly appropriate when multiple handlers use random numbers.
+ *
+ * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
+ */
+@VertxGen
+public interface VertxContextRandom {
+
+  /**
+   * Get or create a secure non blocking random number generator using the current vert.x context. If there is no
+   * current context (i.e.: not running on the eventloop) then a {@link java.lang.IllegalStateException} is thrown.
+   *
+   * @return A secure non blocking random number generator.
+   * @throws IllegalStateException when there is no context available.
+   */
+  static VertxContextRandom current() {
+    final Context currentContext = Vertx.currentContext();
+    if (currentContext != null) {
+      return current(currentContext.owner());
+    }
+
+    throw new IllegalStateException("Not running in a Vert.x Context.");
+  }
+
+  /**
+   * Get or create a secure non blocking random number generator using the current vert.x context. This method will not
+   * throw an exception.
+   *
+   * @return A secure non blocking random number generator.
+   * @param vertx a Vert.x instance.
+   */
+  static VertxContextRandom current(final Vertx vertx) {
+    // try to get the current context
+    Context currentContext = Vertx.currentContext();
+    if (currentContext == null) {
+      currentContext = vertx.getOrCreateContext();
+    }
+    // attempt to load a PRNG from the current context
+    PRNG random = currentContext.get(VertxContextRandom.class.getName());
+
+    if (random == null) {
+      synchronized (currentContext) {
+        // attempt to reload to avoid double creation when we were
+        // waiting for the lock
+        random = currentContext.get(VertxContextRandom.class.getName());
+        if (random == null) {
+          // there was no PRNG in the context, create one
+          random = new PRNG(vertx);
+          // need to make the random final
+          final PRNG rand = random;
+          // save to the context
+          currentContext.put(VertxContextRandom.class.getName(), rand);
+          // add a close hook to shutdown the PRNG
+          currentContext.addCloseHook(v -> rand.close());
+        }
+      }
+    }
+
+    return random;
+  }
+
+  /**
+   * Fills the given byte array with random bytes.
+   *
+   * @param bytes a byte array.
+   */
+  @GenIgnore
+  void nextBytes(byte[] bytes);
+
+  /**
+   * Returns a Base64 mime encoded String of random data with the given length. The length parameter refers to the length
+   * of the String before the encoding step.
+   *
+   * @param length the desired string length before Base64 encoding.
+   * @return A base 64 encoded string.
+   */
+  default String nextString(int length) {
+    // create buffer
+    final byte[] data = new byte[length];
+    // fill with random data
+    nextBytes(data);
+    // encode
+    return Base64.getMimeEncoder().encodeToString(data);
+  }
+
+  /**
+   * Returns a secure random int
+   *
+   * @return random int.
+   */
+  int nextInt();
+}

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/package-info.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/package-info.java
@@ -80,7 +80,7 @@
  *
  * Here's an example of authenticating a user using a simple username/password implementation:
  *
- * [source,java]
+ * [source,$lang]
  * ----
  * {@link examples.AuthCommonExamples#example1}
  * ----
@@ -95,7 +95,7 @@
  *
  * Here's an example of authorising a user:
  *
- * [source,java]
+ * [source,$lang]
  * ----
  * {@link examples.AuthCommonExamples#example2}
  * ----
@@ -129,7 +129,7 @@
  *
  * == Pseudo Random Number Generator
  *
- * Since Secure Random from java can block during the aquisition of entropy from the system, we provide a simple wrapper
+ * Since Secure Random from java can block during the acquisition of entropy from the system, we provide a simple wrapper
  * around it that can be used without the danger of blocking the event loop.
  *
  * By default this PRNG uses a mixed mode, blocking for seeding, non blocking for generating. The PRNG will also reseed
@@ -141,6 +141,20 @@
  *
  * Most users should not need to configure these values unless if you notice that the performance of your application is
  * being affected by the PRNG algorithm.
+ *
+ * === Sharing Pseudo Random Number Generator
+ *
+ * Since the Pseudo Random Number Generator objects are expensive in resources, they consume system entropy which is a
+ * scarce resource it can be wise to share the PRNG's across all your handlers. In order to do this and to make this
+ * available to all languages supported by Vert.x you should look into the {@link io.vertx.ext.auth.VertxContextRandom}.
+ *
+ * This interface relaxes the lifecycle management of PRNG's for the end user and ensures it can be reused across all
+ * your application, for example:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.AuthCommonExamples#example4}
+ * ----
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  * @author <a href="http://tfox.org">Tim Fox</a>

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/package-info.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/package-info.java
@@ -146,7 +146,7 @@
  *
  * Since the Pseudo Random Number Generator objects are expensive in resources, they consume system entropy which is a
  * scarce resource it can be wise to share the PRNG's across all your handlers. In order to do this and to make this
- * available to all languages supported by Vert.x you should look into the {@link io.vertx.ext.auth.VertxContextRandom}.
+ * available to all languages supported by Vert.x you should look into the {@link io.vertx.ext.auth.VertxContextPRNG}.
  *
  * This interface relaxes the lifecycle management of PRNG's for the end user and ensures it can be reused across all
  * your application, for example:


### PR DESCRIPTION
This is a proposal for a vertx context secure PRNG similar to Java's ThreadLocalRandom.

The rationale behind this is that random numbers are used in several places in the project, e.g.:

* Mongo Auth
* Mail Client
* Vertx-web CSRF
* Vertx-web htdigest
* SockJS Base Transport
* JDBC Auth
* Web Session store's
* Web Session
* plus users might also use random numbers in their apps

We know that SecureRandom is a blocking API if there is not enough entropy, so having a PRNG for each of these handlers will consume some entropy plus resources. Using this alternative approach there will be a max of 1 PRNG per vert.x context.