### PR TITLE
Fixes #133

### DIFF
--- a/vertx-auth-jdbc/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/groovy/index.adoc
@@ -116,6 +116,55 @@ conn.updateWithParams("INSERT INTO user VALUES (?, ?, ?)", [
 
 ----
 
+WARNING: Hashing user password with salt can be not enough, this approach his good enough for avoiding rainbow tables
+attacks or precomputed table attacks but if the attacker gets the database it will be easier to setup a brute force
+attack. This kind of attack is slower but all required information is given: the hash and the salt.
+
+To make the hash attack more complex the default strategy allows you to provide an application level list of nonces
+to be used in the computation. This list should not be stored in the database since it add an extra variable to the
+computation that is unknown, making the brute force attack as potentially the only way to crack the hash. You might
+want to refresh the nonces now and then so you should add and never remove entries to the list, for example:
+
+[source,groovy]
+----
+auth.setNonces([
+  "random_hash_1",
+  "random_hash_1"
+])
+
+----
+
+In order to decode there is no change required to the code, however to generate a new user you must specify which
+nonce (by it's index) you want to use. If you look at the previous example, the usage is quite similar:
+
+1. Generate a salt string
+2. Hash the password given the salt string and choosen nonce
+3. Store it to the database
+
+[source,groovy]
+----
+
+auth.setNonces([
+  "random_hash_1",
+  "random_hash_1"
+])
+
+def salt = auth.generateSalt()
+// we will pick the second nonce
+def hash = auth.computeHash("sausages", salt, 1)
+// save to the database
+conn.updateWithParams("INSERT INTO user VALUES (?, ?, ?)", [
+  "tim",
+  hash,
+  salt
+], { res ->
+  if (res.succeeded()) {
+    // success!
+  }
+})
+
+----
+
 == Authentication
 
 When authenticating using this implementation, it assumes `username` and `password` fields are present in the

--- a/vertx-auth-jdbc/src/main/asciidoc/java/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/java/index.adoc
@@ -108,6 +108,42 @@ conn.updateWithParams("INSERT INTO user VALUES (?, ?, ?)", new JsonArray().add("
 });
 ----
 
+WARNING: Hashing user password with salt can be not enough, this approach his good enough for avoiding rainbow tables
+attacks or precomputed table attacks but if the attacker gets the database it will be easier to setup a brute force
+attack. This kind of attack is slower but all required information is given: the hash and the salt.
+
+To make the hash attack more complex the default strategy allows you to provide an application level list of nonces
+to be used in the computation. This list should not be stored in the database since it add an extra variable to the
+computation that is unknown, making the brute force attack as potentially the only way to crack the hash. You might
+want to refresh the nonces now and then so you should add and never remove entries to the list, for example:
+
+[source,java]
+----
+auth.setNonces(new JsonArray().add("random_hash_1").add("random_hash_1"));
+----
+
+In order to decode there is no change required to the code, however to generate a new user you must specify which
+nonce (by it's index) you want to use. If you look at the previous example, the usage is quite similar:
+
+1. Generate a salt string
+2. Hash the password given the salt string and choosen nonce
+3. Store it to the database
+
+[source,java]
+----
+auth.setNonces(new JsonArray().add("random_hash_1").add("random_hash_1"));
+
+String salt = auth.generateSalt();
+// we will pick the second nonce
+String hash = auth.computeHash("sausages", salt, 1);
+// save to the database
+conn.updateWithParams("INSERT INTO user VALUES (?, ?, ?)", new JsonArray().add("tim").add(hash).add(salt), res -> {
+  if (res.succeeded()) {
+    // success!
+  }
+});
+----
+
 == Authentication
 
 When authenticating using this implementation, it assumes `username` and `password` fields are present in the

--- a/vertx-auth-jdbc/src/main/asciidoc/js/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/js/index.adoc
@@ -118,6 +118,55 @@ conn.updateWithParams("INSERT INTO user VALUES (?, ?, ?)", [
 
 ----
 
+WARNING: Hashing user password with salt can be not enough, this approach his good enough for avoiding rainbow tables
+attacks or precomputed table attacks but if the attacker gets the database it will be easier to setup a brute force
+attack. This kind of attack is slower but all required information is given: the hash and the salt.
+
+To make the hash attack more complex the default strategy allows you to provide an application level list of nonces
+to be used in the computation. This list should not be stored in the database since it add an extra variable to the
+computation that is unknown, making the brute force attack as potentially the only way to crack the hash. You might
+want to refresh the nonces now and then so you should add and never remove entries to the list, for example:
+
+[source,js]
+----
+auth.setNonces([
+  "random_hash_1",
+  "random_hash_1"
+]);
+
+----
+
+In order to decode there is no change required to the code, however to generate a new user you must specify which
+nonce (by it's index) you want to use. If you look at the previous example, the usage is quite similar:
+
+1. Generate a salt string
+2. Hash the password given the salt string and choosen nonce
+3. Store it to the database
+
+[source,js]
+----
+
+auth.setNonces([
+  "random_hash_1",
+  "random_hash_1"
+]);
+
+var salt = auth.generateSalt();
+// we will pick the second nonce
+var hash = auth.computeHash("sausages", salt, 1);
+// save to the database
+conn.updateWithParams("INSERT INTO user VALUES (?, ?, ?)", [
+  "tim",
+  hash,
+  salt
+], function (res, res_err) {
+  if (res_err == null) {
+    // success!
+  }
+});
+
+----
+
 == Authentication
 
 When authenticating using this implementation, it assumes `username` and `password` fields are present in the

--- a/vertx-auth-jdbc/src/main/asciidoc/kotlin/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/kotlin/index.adoc
@@ -114,6 +114,51 @@ conn.updateWithParams("INSERT INTO user VALUES (?, ?, ?)", json {
 
 ----
 
+WARNING: Hashing user password with salt can be not enough, this approach his good enough for avoiding rainbow tables
+attacks or precomputed table attacks but if the attacker gets the database it will be easier to setup a brute force
+attack. This kind of attack is slower but all required information is given: the hash and the salt.
+
+To make the hash attack more complex the default strategy allows you to provide an application level list of nonces
+to be used in the computation. This list should not be stored in the database since it add an extra variable to the
+computation that is unknown, making the brute force attack as potentially the only way to crack the hash. You might
+want to refresh the nonces now and then so you should add and never remove entries to the list, for example:
+
+[source,kotlin]
+----
+auth.setNonces(json {
+  array("random_hash_1", "random_hash_1")
+})
+
+----
+
+In order to decode there is no change required to the code, however to generate a new user you must specify which
+nonce (by it's index) you want to use. If you look at the previous example, the usage is quite similar:
+
+1. Generate a salt string
+2. Hash the password given the salt string and choosen nonce
+3. Store it to the database
+
+[source,kotlin]
+----
+
+auth.setNonces(json {
+  array("random_hash_1", "random_hash_1")
+})
+
+var salt = auth.generateSalt()
+// we will pick the second nonce
+var hash = auth.computeHash("sausages", salt, 1)
+// save to the database
+conn.updateWithParams("INSERT INTO user VALUES (?, ?, ?)", json {
+  array("tim", hash, salt)
+}, { res ->
+  if (res.succeeded()) {
+    // success!
+  }
+})
+
+----
+
 == Authentication
 
 When authenticating using this implementation, it assumes `username` and `password` fields are present in the

--- a/vertx-auth-jdbc/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/ruby/index.adoc
@@ -118,6 +118,55 @@ conn.update_with_params("INSERT INTO user VALUES (?, ?, ?)", [
 
 ----
 
+WARNING: Hashing user password with salt can be not enough, this approach his good enough for avoiding rainbow tables
+attacks or precomputed table attacks but if the attacker gets the database it will be easier to setup a brute force
+attack. This kind of attack is slower but all required information is given: the hash and the salt.
+
+To make the hash attack more complex the default strategy allows you to provide an application level list of nonces
+to be used in the computation. This list should not be stored in the database since it add an extra variable to the
+computation that is unknown, making the brute force attack as potentially the only way to crack the hash. You might
+want to refresh the nonces now and then so you should add and never remove entries to the list, for example:
+
+[source,ruby]
+----
+auth.set_nonces([
+  "random_hash_1",
+  "random_hash_1"
+])
+
+----
+
+In order to decode there is no change required to the code, however to generate a new user you must specify which
+nonce (by it's index) you want to use. If you look at the previous example, the usage is quite similar:
+
+1. Generate a salt string
+2. Hash the password given the salt string and choosen nonce
+3. Store it to the database
+
+[source,ruby]
+----
+
+auth.set_nonces([
+  "random_hash_1",
+  "random_hash_1"
+])
+
+salt = auth.generate_salt()
+# we will pick the second nonce
+hash = auth.compute_hash("sausages", salt, 1)
+# save to the database
+conn.update_with_params("INSERT INTO user VALUES (?, ?, ?)", [
+  "tim",
+  hash,
+  salt
+]) { |res_err,res|
+  if (res_err == nil)
+    # success!
+  end
+}
+
+----
+
 == Authentication
 
 When authenticating using this implementation, it assumes `username` and `password` fields are present in the

--- a/vertx-auth-jdbc/src/main/java/examples/AuthJDBCExamples.java
+++ b/vertx-auth-jdbc/src/main/java/examples/AuthJDBCExamples.java
@@ -86,4 +86,23 @@ public class AuthJDBCExamples {
       }
     });
   }
+
+  public void example10(JDBCAuth auth) {
+    auth.setNonces(new JsonArray().add("random_hash_1").add("random_hash_1"));
+  }
+
+  public void example11(JDBCAuth auth, SQLConnection conn) {
+
+    auth.setNonces(new JsonArray().add("random_hash_1").add("random_hash_1"));
+
+    String salt = auth.generateSalt();
+    // we will pick the second nonce
+    String hash = auth.computeHash("sausages", salt, 1);
+    // save to the database
+    conn.updateWithParams("INSERT INTO user VALUES (?, ?, ?)", new JsonArray().add("tim").add(hash).add(salt), res -> {
+      if (res.succeeded()) {
+        // success!
+      }
+    });
+  }
 }

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCHashStrategy.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCHashStrategy.java
@@ -18,6 +18,8 @@ package io.vertx.ext.auth.jdbc;
 
 import io.vertx.core.json.JsonArray;
 
+import java.util.List;
+
 /**
  * Determines how the hashing is computed in the implementation
  *
@@ -38,9 +40,10 @@ public interface JDBCHashStrategy {
    * Compute the hashed password given the unhashed password and the salt
    * @param password  the unhashed password
    * @param salt  the salt
+   * @param version the nonce version to use
    * @return  the hashed password
    */
-  String computeHash(String password, String salt);
+  String computeHash(String password, String salt, int version);
 
   /**
    * Retrieve the hashed password from the result of the authentication query
@@ -55,4 +58,17 @@ public interface JDBCHashStrategy {
    * @return  the salt
    */
   String getSalt(JsonArray row);
+
+  /**
+   * Sets a ordered list of nonces where each position corresponds to a version.
+   *
+   * The nonces are supposed not to be stored in the underlying jdbc storage but to
+   * be provided as a application configuration. The idea is to add one extra variable
+   * to the hash function in order to make breaking the passwords using rainbow tables
+   * or precomputed hashes harder. Leaving the attacker only with the brute force
+   * approach.
+   *
+   * @param nonces a List of non null Strings.
+   */
+  void setNonces(List<String> nonces);
 }

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/package-info.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/package-info.java
@@ -114,6 +114,32 @@
  * {@link examples.AuthJDBCExamples#example9}
  * ----
  *
+ * WARNING: Hashing user password with salt can be not enough, this approach his good enough for avoiding rainbow tables
+ * attacks or precomputed table attacks but if the attacker gets the database it will be easier to setup a brute force
+ * attack. This kind of attack is slower but all required information is given: the hash and the salt.
+ *
+ * To make the hash attack more complex the default strategy allows you to provide an application level list of nonces
+ * to be used in the computation. This list should not be stored in the database since it add an extra variable to the
+ * computation that is unknown, making the brute force attack as potentially the only way to crack the hash. You might
+ * want to refresh the nonces now and then so you should add and never remove entries to the list, for example:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.AuthJDBCExamples#example10}
+ * ----
+ *
+ * In order to decode there is no change required to the code, however to generate a new user you must specify which
+ * nonce (by it's index) you want to use. If you look at the previous example, the usage is quite similar:
+ *
+ * 1. Generate a salt string
+ * 2. Hash the password given the salt string and choosen nonce
+ * 3. Store it to the database
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.AuthJDBCExamples#example11}
+ * ----
+ *
  * == Authentication
  *
  * When authenticating using this implementation, it assumes `username` and `password` fields are present in the

--- a/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthTest.java
+++ b/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthTest.java
@@ -16,6 +16,7 @@
 
 package io.vertx.ext.auth.test.jdbc;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.jdbc.JDBCAuth;
 import io.vertx.ext.jdbc.JDBCClient;
@@ -49,6 +50,9 @@ public class JDBCAuthTest extends VertxTestBase {
     SQL.add("insert into roles_perms values ('dev', 'eat_pizza');");
     SQL.add("insert into roles_perms values ('admin', 'merge_pr');");
 
+    // add another user using nonces
+    SQL.add("insert into user values ('paulo', '4EFC18C18180F20905B79EA06D24F866382E9888957195E3C36EFA603C5194AD4E56685579FC4A9C5144EE093B00E1E208C344E80703DEEE28D4FCF3C7778F24$0', 'E1BDFAF66074169738F593626ABDE48E013CA17D87CDFF07F18FC5D7FBBFA427');");
+
     // and a second set of tables with slight differences
 
     SQL.add("drop table if exists user2;");
@@ -65,6 +69,8 @@ public class JDBCAuthTest extends VertxTestBase {
     SQL.add("insert into roles_perms2 values ('dev', 'eat_pizza');");
     SQL.add("insert into roles_perms2 values ('admin', 'merge_pr');");
 
+    // add another user using nonces
+    SQL.add("insert into user2 values ('paulo', '4EFC18C18180F20905B79EA06D24F866382E9888957195E3C36EFA603C5194AD4E56685579FC4A9C5144EE093B00E1E208C344E80703DEEE28D4FCF3C7778F24$0', 'E1BDFAF66074169738F593626ABDE48E013CA17D87CDFF07F18FC5D7FBBFA427');");
   }
 
   @BeforeClass
@@ -87,8 +93,7 @@ public class JDBCAuthTest extends VertxTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    authProvider = createProvider();
-
+    authProvider = createProvider().setNonces(new JsonArray().add("queiM3ayei1ahCheicupohphioveer0O"));
   }
 
   protected JDBCAuth createProvider() {
@@ -186,6 +191,17 @@ public class JDBCAuthTest extends VertxTestBase {
         assertFalse(has);
         testComplete();
       }));
+    }));
+    await();
+  }
+
+  @Test
+  public void testAuthenticateWithNonce() {
+    JsonObject authInfo = new JsonObject();
+    authInfo.put("username", "paulo").put("password", "secret");
+    authProvider.authenticate(authInfo, onSuccess(user -> {
+      assertNotNull(user);
+      testComplete();
     }));
     await();
   }


### PR DESCRIPTION
This fix is 100% backwards compatible as shown in test.

The choosen approach is to use a application level configuration of nonces that is **NOT** expected to be stored in the database, this way we present precomputed hash attacks and rainbow table attacks, leaving room only for brute force attacks.