### PR TITLE
add a configuration option to use HMac secrets without a keystore

### DIFF
--- a/vertx-auth-common/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-auth-common/src/main/asciidoc/dataobjects.adoc
@@ -48,3 +48,19 @@
 |[[type]]`type`|`String`|-
 |===
 
+[[SecretOptions]]
+== SecretOptions
+
+++++
+ Options describing a secret.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[secret]]`secret`|`String`|-
+|[[type]]`type`|`String`|-
+|===
+

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/SecretOptions.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/SecretOptions.java
@@ -1,0 +1,57 @@
+package io.vertx.ext.auth;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Options describing a secret.
+ *
+ * @author <a href="mailto:marco@viafoura.com">Marco Monaco</a>
+ */
+@DataObject(generateConverter = true)
+public class SecretOptions {
+  // Defaults
+  private static final String TYPE = "HS256";
+
+  private String type;
+  private String secret;
+
+  public SecretOptions() { init(); }
+
+  public SecretOptions(SecretOptions other) {
+    type = other.getType();
+    secret = other.getSecret();
+  }
+
+  /**
+   * Constructor to create an options from JSON
+   *
+   * @param json the JSON
+   */
+  public SecretOptions(JsonObject json) {
+    init();
+    SecretOptionsConverter.fromJson(json, this);
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public SecretOptions setType(String type) {
+    this.type = type;
+    return this;
+  }
+
+  public String getSecret() {
+    return secret;
+  }
+
+  public SecretOptions setSecret(String secret) {
+    this.secret = secret;
+    return this;
+  }
+
+  private void init() {
+    type = TYPE;
+  }
+}

--- a/vertx-auth-jwt/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/dataobjects.adoc
@@ -31,6 +31,7 @@ Set the issuer
 |[[keyStore]]`keyStore`|`link:dataobjects.html#KeyStoreOptions[KeyStoreOptions]`|-
 |[[permissionsClaimKey]]`permissionsClaimKey`|`String`|-
 |[[pubSecKeys]]`pubSecKeys`|`Array of link:dataobjects.html#PubSecKeyOptions[PubSecKeyOptions]`|-
+|[[secrets]]`secrets`|`Array of link:dataobjects.html#SecretOptions[SecretOptions]`|-
 |===
 
 [[JWTKeyStoreOptions]]

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/JWTAuthOptions.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/JWTAuthOptions.java
@@ -19,6 +19,7 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.KeyStoreOptions;
 import io.vertx.ext.auth.PubSecKeyOptions;
+import io.vertx.ext.auth.SecretOptions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +40,7 @@ public class JWTAuthOptions {
   private String permissionsClaimKey;
   private KeyStoreOptions keyStore;
   private List<PubSecKeyOptions> pubSecKeys;
+  private List<SecretOptions> secrets;
   private List<String> audience;
   private String issuer;
   private boolean ignoreExpiration;
@@ -59,6 +61,7 @@ public class JWTAuthOptions {
     permissionsClaimKey = other.getPermissionsClaimKey();
     keyStore = other.getKeyStore();
     pubSecKeys = other.getPubSecKeys();
+    secrets = other.getSecrets();
     audience = other.getAudience();
     issuer = other.getIssuer();
     ignoreExpiration = other.isIgnoreExpiration();
@@ -104,6 +107,22 @@ public class JWTAuthOptions {
 
   public JWTAuthOptions setPubSecKeys(List<PubSecKeyOptions> pubSecKeys) {
     this.pubSecKeys = pubSecKeys;
+    return this;
+  }
+
+  public List<SecretOptions> getSecrets() {
+    return secrets;
+  }
+
+  public void setSecrets(List<SecretOptions> secrets) {
+    this.secrets = secrets;
+  }
+
+  public JWTAuthOptions addSecret(SecretOptions secret) {
+    if (this.secrets == null) {
+      this.secrets = new ArrayList<>();
+    }
+    this.secrets.add(secret);
     return this;
   }
 

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
@@ -26,11 +26,12 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.KeyStoreOptions;
 import io.vertx.ext.auth.PubSecKeyOptions;
+import io.vertx.ext.auth.SecretOptions;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import io.vertx.ext.auth.jwt.JWTOptions;
-import io.vertx.ext.jwt.*;
+import io.vertx.ext.jwt.JWT;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -88,6 +89,14 @@ public class JWTAuthProviderImpl implements JWTAuth {
         if (keys != null) {
           for (PubSecKeyOptions key : keys) {
             this.jwt.addKeyPair(key.getType(), key.getPublicKey(), key.getSecretKey());
+          }
+        }
+
+        final List<SecretOptions> secrets = config.getSecrets();
+
+        if (secrets != null) {
+          for (SecretOptions secret: secrets) {
+            this.jwt.addSecret(secret.getType(), secret.getSecret());
           }
         }
       }

--- a/vertx-auth-jwt/src/main/kotlin/io/vertx/kotlin/ext/auth/jwt/JWTAuthOptions.kt
+++ b/vertx-auth-jwt/src/main/kotlin/io/vertx/kotlin/ext/auth/jwt/JWTAuthOptions.kt
@@ -3,6 +3,7 @@ package io.vertx.kotlin.ext.auth.jwt
 import io.vertx.ext.auth.jwt.JWTAuthOptions
 import io.vertx.ext.auth.KeyStoreOptions
 import io.vertx.ext.auth.PubSecKeyOptions
+import io.vertx.ext.auth.SecretOptions
 
 /**
  * A function providing a DSL for building [io.vertx.ext.auth.jwt.JWTAuthOptions] objects.
@@ -16,6 +17,7 @@ import io.vertx.ext.auth.PubSecKeyOptions
  * @param keyStore 
  * @param permissionsClaimKey 
  * @param pubSecKeys 
+ * @param secrets 
  *
  * <p/>
  * NOTE: This function has been automatically generated from the [io.vertx.ext.auth.jwt.JWTAuthOptions original] using Vert.x codegen.
@@ -27,7 +29,8 @@ fun JWTAuthOptions(
   issuer: String? = null,
   keyStore: io.vertx.ext.auth.KeyStoreOptions? = null,
   permissionsClaimKey: String? = null,
-  pubSecKeys: Iterable<io.vertx.ext.auth.PubSecKeyOptions>? = null): JWTAuthOptions = io.vertx.ext.auth.jwt.JWTAuthOptions().apply {
+  pubSecKeys: Iterable<io.vertx.ext.auth.PubSecKeyOptions>? = null,
+  secrets: Iterable<io.vertx.ext.auth.SecretOptions>? = null): JWTAuthOptions = io.vertx.ext.auth.jwt.JWTAuthOptions().apply {
 
   if (audience != null) {
     this.setAudience(audience.toList())
@@ -51,6 +54,9 @@ fun JWTAuthOptions(
   }
   if (pubSecKeys != null) {
     this.setPubSecKeys(pubSecKeys.toList())
+  }
+  if (secrets != null) {
+    this.setSecrets(secrets.toList())
   }
 }
 


### PR DESCRIPTION
You added a way to pass in arbitrary secrets to HMAC on the JWT object recently, but there's no way to use that in JwtAuth yet. Adding a configuration hook for that