### PR TITLE
Align OAuth2 API with common

### DIFF
--- a/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
+++ b/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
@@ -20,6 +20,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.*;
 import io.vertx.ext.auth.oauth2.providers.KeycloakAuth;
 
@@ -53,7 +54,7 @@ public class AuthOAuth2Examples {
 
     String code = "xxxxxxxxxxxxxxxxxxxxxxxx"; // the code is provided as a url parameter by github callback call
 
-    oauth2.getToken(new JsonObject().put("code", code).put("redirect_uri", "http://localhost:8080/callback"), res -> {
+    oauth2.authenticate(new JsonObject().put("code", code).put("redirect_uri", "http://localhost:8080/callback"), res -> {
       if (res.failed()) {
         // error, the code provided is not valid
       } else {
@@ -91,12 +92,12 @@ public class AuthOAuth2Examples {
 
     // Callbacks
     // Save the access token
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         System.err.println("Access Token Error: " + res.cause().getMessage());
       } else {
         // Get the access token object (the authorization code is given from the previous step).
-        AccessToken token = res.result();
+        User token = res.result();
       }
     });
   }
@@ -112,12 +113,12 @@ public class AuthOAuth2Examples {
 
     // Callbacks
     // Save the access token
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         System.err.println("Access Token Error: " + res.cause().getMessage());
       } else {
         // Get the access token object (the authorization code is given from the previous step).
-        AccessToken token = res.result();
+        User token = res.result();
 
         oauth2.api(HttpMethod.GET, "/users", new JsonObject().put("access_token", token.principal().getString("access_token")), res2 -> {
           // the user object should be returned here...
@@ -142,12 +143,12 @@ public class AuthOAuth2Examples {
 
     // Callbacks
     // Save the access token
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         System.err.println("Access Token Error: " + res.cause().getMessage());
       } else {
         // Get the access token object (the authorization code is given from the previous step).
-        AccessToken token = res.result();
+        User token = res.result();
       }
     });
   }
@@ -193,11 +194,11 @@ public class AuthOAuth2Examples {
     OAuth2Auth oauth2 = KeycloakAuth.create(vertx, OAuth2FlowType.PASSWORD, keycloakJson);
 
     // first get a token (authenticate)
-    oauth2.getToken(new JsonObject().put("username", "user").put("password", "secret"), res -> {
+    oauth2.authenticate(new JsonObject().put("username", "user").put("password", "secret"), res -> {
       if (res.failed()) {
         // error handling...
       } else {
-        AccessToken token = res.result();
+        AccessToken token = (AccessToken) res.result();
 
         // now check for permissions
         token.isAuthorised("account:manage-account", r -> {

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Auth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Auth.java
@@ -115,9 +115,12 @@ public interface OAuth2Auth extends AuthProvider {
   /**
    * Returns the Access Token object.
    *
+   * @deprecated use {@link AuthProvider#authenticate(JsonObject, Handler)} instead.
+   *
    * @param params - JSON with the options, each flow requires different options.
    * @param handler - The handler returning the results.
    */
+  @Deprecated
   void getToken(JsonObject params, Handler<AsyncResult<AccessToken>> handler);
 
   /**

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -83,7 +83,13 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
 
   @Override
   public void authenticate(JsonObject authInfo, Handler<AsyncResult<User>> resultHandler) {
-    resultHandler.handle(Future.failedFuture("OAuth2 cannot be used for AuthN (the implementation is a Client Relay only)"));
+    flow.getToken(authInfo, getToken -> {
+      if (getToken.failed()) {
+        resultHandler.handle(Future.failedFuture(getToken.cause()));
+      } else {
+        resultHandler.handle(Future.succeededFuture(getToken.result()));
+      }
+    });
   }
 
   @Override
@@ -92,8 +98,8 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
   }
 
   @Override
-  public void getToken(JsonObject params, Handler<AsyncResult<AccessToken>> handler) {
-    flow.getToken(params, handler);
+  public void getToken(JsonObject credentials, Handler<AsyncResult<AccessToken>> handler) {
+    flow.getToken(credentials, handler);
   }
 
   @Override

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AccessTokenTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AccessTokenTest.java
@@ -3,6 +3,7 @@ package io.vertx.ext.auth.test.oauth2;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.AccessToken;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
@@ -141,11 +142,11 @@ public class OAuth2AccessTokenTest extends VertxTestBase {
   @Test
   public void createAccessToken() {
     config = oauthConfig;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        User token = res.result();
         assertNotNull(token);
         assertNotNull(token.principal());
         testComplete();
@@ -157,11 +158,11 @@ public class OAuth2AccessTokenTest extends VertxTestBase {
   @Test
   public void tokenShouldNotBeExpired() {
     config = oauthConfig;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        AccessToken token = (AccessToken) res.result();
         assertFalse(token.expired());
         testComplete();
       }
@@ -172,11 +173,11 @@ public class OAuth2AccessTokenTest extends VertxTestBase {
   @Test
   public void tokenShouldBeExpiredWhenExpirationDateIsInThePast() {
     config = oauthConfig;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        AccessToken token = (AccessToken) res.result();
         // hack the token to set the expires_at (to yesterday)
         token.principal().put("expires_at", System.currentTimeMillis() - 24 * 60 * 60 * 1000);
         assertTrue(token.expired());
@@ -189,11 +190,11 @@ public class OAuth2AccessTokenTest extends VertxTestBase {
   @Test
   public void whenRefreshingTokenShouldGetNewAccessToken() {
     config = oauthConfig;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        AccessToken token = (AccessToken) res.result();
         final long origTTl = token.principal().getLong("expires_at");
         // refresh the token
         config = refreshConfig;
@@ -213,11 +214,11 @@ public class OAuth2AccessTokenTest extends VertxTestBase {
   @Test
   public void shouldRevokeAToken() {
     config = oauthConfig;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        AccessToken token = (AccessToken) res.result();
         // refresh the token
         config = revokeConfig;
         token.revoke("refresh_token", v -> {

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthCodeErrorTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthCodeErrorTest.java
@@ -89,7 +89,7 @@ public class OAuth2AuthCodeErrorTest extends VertxTestBase {
   @Test
   public void getToken() {
     config = oauthConfig;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         assertNotNull(res.cause());
         testComplete();

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthCodeTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthCodeTest.java
@@ -3,6 +3,7 @@ package io.vertx.ext.auth.test.oauth2;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.AccessToken;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
@@ -97,11 +98,11 @@ public class OAuth2AuthCodeTest extends VertxTestBase {
   @Test
   public void getToken() {
     config = oauthConfig;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        User token = res.result();
         assertNotNull(token);
         assertNotNull(token.principal());
         testComplete();

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthJWTTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthJWTTest.java
@@ -3,6 +3,7 @@ package io.vertx.ext.auth.test.oauth2;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.AccessToken;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.providers.GoogleAuth;
@@ -82,11 +83,11 @@ public class OAuth2AuthJWTTest extends VertxTestBase {
     JsonObject jwt = new JsonObject()
       .put("scope", "https://www.googleapis.com/auth/devstorage.readonly");
 
-    oauth2.getToken(jwt, res -> {
+    oauth2.authenticate(jwt, res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        User token = res.result();
         assertNotNull(token);
         assertNotNull(token.principal());
         testComplete();

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ClientTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ClientTest.java
@@ -3,6 +3,7 @@ package io.vertx.ext.auth.test.oauth2;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.AccessToken;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
@@ -76,11 +77,11 @@ public class OAuth2ClientTest extends VertxTestBase {
   @Test
   public void getToken() {
     config = oauthConfig;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        User token = res.result();
         assertNotNull(token);
         assertNotNull(token.principal());
         testComplete();

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ErrorsTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ErrorsTest.java
@@ -64,7 +64,7 @@ public class OAuth2ErrorsTest extends VertxTestBase {
         .put("type", "OAuthException")
         .put("code", 190));
 
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         assertEquals("Error validating access token: User USER_ID has not authorized application APP_ID.", res.cause().getMessage());
         testComplete();
@@ -83,7 +83,7 @@ public class OAuth2ErrorsTest extends VertxTestBase {
       .put("error_description", "The client_id and/or client_secret passed are incorrect.")
       .put("error_uri", "https://developer.github.com/v3/oauth/#incorrect-client-credentials");
 
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         assertEquals("The client_id and/or client_secret passed are incorrect.", res.cause().getMessage());
         testComplete();
@@ -99,7 +99,7 @@ public class OAuth2ErrorsTest extends VertxTestBase {
     fixture = new JsonObject()
       .put("error", "incorrect_client_credentials");
 
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         assertEquals("incorrect_client_credentials", res.cause().getMessage());
         testComplete();
@@ -115,7 +115,7 @@ public class OAuth2ErrorsTest extends VertxTestBase {
     fixture = new JsonObject()
       .put("error", 190);
 
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         assertEquals("190", res.cause().getMessage());
         testComplete();

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2FailureTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2FailureTest.java
@@ -78,7 +78,7 @@ public class OAuth2FailureTest extends VertxTestBase {
   public void getUnauthorizedToken() {
     config = oauthConfig;
     code = 401;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         assertEquals("Unauthorized", res.cause().getMessage());
         testComplete();
@@ -93,7 +93,7 @@ public class OAuth2FailureTest extends VertxTestBase {
   public void getTokenServerCrash() {
     config = oauthConfig;
     code = 500;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         assertEquals("Internal Server Error", res.cause().getMessage());
         testComplete();
@@ -110,7 +110,7 @@ public class OAuth2FailureTest extends VertxTestBase {
       .setClientID("client-id")
       .setClientSecret("client-secret")
       .setSite("http://zlouklfoux.net.com.info.pimpo.molo"));
-    auth.getToken(tokenConfig, res -> {
+    auth.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         assertThat(res.cause(), instanceOf(UnknownHostException.class));
         testComplete();

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2KeycloakTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2KeycloakTest.java
@@ -33,11 +33,11 @@ public class OAuth2KeycloakTest extends VertxTestBase {
   @Test
   @Ignore
   public void testFullCycle() {
-    oauth2.getToken(new JsonObject().put("username", "pmlopes").put("password", "password"), res -> {
+    oauth2.authenticate(new JsonObject().put("username", "pmlopes").put("password", "password"), res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        AccessToken token = (AccessToken) res.result();
         assertNotNull(token);
         assertNotNull(token.principal());
 
@@ -70,11 +70,11 @@ public class OAuth2KeycloakTest extends VertxTestBase {
   @Test
   @Ignore
   public void testLogout() {
-    oauth2.getToken(new JsonObject().put("username", "pmlopes").put("password", "password"), res -> {
+    oauth2.authenticate(new JsonObject().put("username", "pmlopes").put("password", "password"), res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        AccessToken token = (AccessToken) res.result();
         assertNotNull(token);
         assertNotNull(token.principal());
 

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2PasswordTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2PasswordTest.java
@@ -3,6 +3,7 @@ package io.vertx.ext.auth.test.oauth2;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.AccessToken;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
@@ -84,11 +85,11 @@ public class OAuth2PasswordTest extends VertxTestBase {
   @Test
   public void getToken() {
     config = oauthConfig;
-    oauth2.getToken(tokenConfig, res -> {
+    oauth2.authenticate(tokenConfig, res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {
-        AccessToken token = res.result();
+        User token = res.result();
         assertNotNull(token);
         assertNotNull(token.principal());
         testComplete();


### PR DESCRIPTION
The issue is that common defines:

* authenticate(JsonObject, Handler<AsyncResult<User>>)

while Oauth2 was not implementing it and exposing:

* getToken(JsonObject, Handler<AsyncResult<AccessToken>>)

Where AccessToken is a sub class of User.

So I'm proposing to deprecate `getToken` while calling `authenticate` and `authenticate` will be the same code that the old `getToken` was doing.

We now can have a unified way to authenticate across all auth providers.

The PR is quite simple and backwards compatible. 
