### PR TITLE
fix: NPE when calling JWTOptions.getNoTimestamp()

### DIFF
--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/JWTOptions.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/JWTOptions.java
@@ -155,7 +155,7 @@ public class JWTOptions {
   }
 
   public boolean getNoTimestamp() {
-    return json.getBoolean("noTimestamp");
+    return json.getBoolean("noTimestamp", false);
   }
 
   /**


### PR DESCRIPTION
The problem is simple, when you create a blank JWTOptions or from JsonObject without noTimestamp field, and then call getNoTimestamp(), it will throw a NPE, because JsonObject. getBoolean() will return NULL, but the return type is boolean not Boolean.