### PR TITLE
Added support for generating random ints with a bound

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/PRNG.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/PRNG.java
@@ -110,4 +110,12 @@ public class PRNG implements VertxContextPRNG {
     dirty = true;
     return rand;
   }
+
+  @Override
+  public int nextInt(final int bound) {
+    final int rand = random.nextInt(bound);
+    dirty = true;
+    return rand;
+  }
+
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
@@ -138,4 +138,13 @@ public interface VertxContextPRNG {
    * @return random int.
    */
   int nextInt();
+
+  /**
+   * Returns a secure random int, between 0 (inclusive) and the specified bound (exclusive).
+   *
+   * @param bound the upper bound (exclusive), which must be positive.
+   * @return random int.
+   */
+  int nextInt(int bound);
+
 }


### PR DESCRIPTION
I want to use the Vert.x managed `Random` for picking a random element from a list.

Because it's not trivial to calculate `randomInt(int bound)` from `randomInt()`, I made this PR.