### PR TITLE
Remove shutdown hooks as timers would be canceled in any case

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
@@ -77,8 +77,6 @@ public interface VertxContextPRNG {
           final PRNG rand = random;
           // save to the context
           context.put(contextKey, rand);
-          // add a close hook to shutdown the PRNG
-          context.addCloseHook(v -> rand.close());
         }
       }
     }
@@ -101,11 +99,7 @@ public interface VertxContextPRNG {
     }
 
     // we are not running on a vert.x context, fallback to create a new instance
-    final PRNG random = new PRNG(vertx);
-    // add a close hook to shutdown the PRNG
-    vertx.getOrCreateContext().addCloseHook(v -> random.close());
-
-    return random;
+    return new PRNG(vertx);
   }
 
   /**


### PR DESCRIPTION
Fixes #212 

This avoids the locking by not adding the shutdown hook. Since the hook is purely cancelling a timer, this is not really relevant as if the vertx instance is shutdown all timers are cancelled.