### PR TITLE
Fixes #165

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/flow/AbstractOAuth2Flow.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/flow/AbstractOAuth2Flow.java
@@ -66,7 +66,7 @@ abstract class AbstractOAuth2Flow implements OAuth2Flow {
     form.put("client_id", config.getClientID());
     form.put("grant_type", grantType);
 
-    if (config.getClientSecretParameterName() != null) {
+    if (config.getClientSecretParameterName() != null && !config.isUseBasicAuthorizationHeader()) {
       form.put(config.getClientSecretParameterName(), config.getClientSecret());
     }
 

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AccessTokenTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AccessTokenTest.java
@@ -57,7 +57,6 @@ public class OAuth2AccessTokenTest extends VertxTestBase {
   private static final JsonObject oauthConfig = new JsonObject()
       .put("code", "code")
       .put("redirect_uri", "http://callback.com")
-      .put("client_secret", "client-secret")
       .put("grant_type", "authorization_code")
       .put("client_id", "client-id");
 

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthCodeErrorTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthCodeErrorTest.java
@@ -32,7 +32,6 @@ public class OAuth2AuthCodeErrorTest extends VertxTestBase {
   private static final JsonObject oauthConfig = new JsonObject()
       .put("code", "code")
       .put("redirect_uri", "http://callback.com")
-      .put("client_secret", "client-secret")
       .put("grant_type", "authorization_code")
       .put("client_id", "client-id");
 

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthCodeTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthCodeTest.java
@@ -35,7 +35,6 @@ public class OAuth2AuthCodeTest extends VertxTestBase {
   private static final JsonObject oauthConfig = new JsonObject()
       .put("code", "code")
       .put("redirect_uri", "http://callback.com")
-      .put("client_secret", "client-secret")
       .put("grant_type", "authorization_code")
       .put("client_id", "client-id");
 

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ClientTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ClientTest.java
@@ -32,8 +32,7 @@ public class OAuth2ClientTest extends VertxTestBase {
 
   private static final JsonObject oauthConfig = new JsonObject()
       .put("grant_type", "client_credentials")
-      .put("client_id", "client-id")
-      .put("client_secret", "client-secret");
+      .put("client_id", "client-id");
 
   protected OAuth2Auth oauth2;
   private HttpServer server;

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2FailureTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2FailureTest.java
@@ -25,7 +25,6 @@ public class OAuth2FailureTest extends VertxTestBase {
   private static final JsonObject oauthConfig = new JsonObject()
       .put("code", "code")
       .put("redirect_uri", "http://callback.com")
-      .put("client_secret", "client-secret")
       .put("grant_type", "authorization_code")
       .put("client_id", "client-id");
 

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2PasswordTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2PasswordTest.java
@@ -33,7 +33,6 @@ public class OAuth2PasswordTest extends VertxTestBase {
 
   private static final JsonObject oauthConfig = new JsonObject()
       .put("password", "secret")
-      .put("client_secret", "client-secret")
       .put("grant_type", "password")
       .put("client_id", "client-id")
       .put("username", "alice");


### PR DESCRIPTION
This omits the client_secret parameter from the form body when basic authorization is used.