### PR TITLE
3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
   </parent>
 
   <artifactId>vertx-auth</artifactId>
-  <version>3.6.2</version>
+  <version>3.6.3-SNAPSHOT</version>
 
   <name>Vert.x Auth</name>
 
   <properties>
-    <stack.version>3.6.2</stack.version>
+    <stack.version>3.6.3-SNAPSHOT</stack.version>
     <doc.skip>true</doc.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
   </parent>
 
   <artifactId>vertx-auth</artifactId>
-  <version>3.6.1-SNAPSHOT</version>
+  <version>3.6.1</version>
 
   <name>Vert.x Auth</name>
 
   <properties>
-    <stack.version>3.6.1-SNAPSHOT</stack.version>
+    <stack.version>3.6.1</stack.version>
     <doc.skip>true</doc.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
   </parent>
 
   <artifactId>vertx-auth</artifactId>
-  <version>3.6.3</version>
+  <version>3.6.4-SNAPSHOT</version>
 
   <name>Vert.x Auth</name>
 
   <properties>
-    <stack.version>3.6.3</stack.version>
+    <stack.version>3.6.4-SNAPSHOT</stack.version>
     <doc.skip>true</doc.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
   </parent>
 
   <artifactId>vertx-auth</artifactId>
-  <version>3.6.1</version>
+  <version>3.6.2-SNAPSHOT</version>
 
   <name>Vert.x Auth</name>
 
   <properties>
-    <stack.version>3.6.1</stack.version>
+    <stack.version>3.6.2-SNAPSHOT</stack.version>
     <doc.skip>true</doc.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
   </parent>
 
   <artifactId>vertx-auth</artifactId>
-  <version>3.6.2-SNAPSHOT</version>
+  <version>3.6.2</version>
 
   <name>Vert.x Auth</name>
 
   <properties>
-    <stack.version>3.6.2-SNAPSHOT</stack.version>
+    <stack.version>3.6.2</stack.version>
     <doc.skip>true</doc.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
   </parent>
 
   <artifactId>vertx-auth</artifactId>
-  <version>3.6.3-SNAPSHOT</version>
+  <version>3.6.3</version>
 
   <name>Vert.x Auth</name>
 
   <properties>
-    <stack.version>3.6.3-SNAPSHOT</stack.version>
+    <stack.version>3.6.3</stack.version>
     <doc.skip>true</doc.skip>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
   </parent>
 
   <artifactId>vertx-auth</artifactId>
-  <version>3.6.0</version>
+  <version>3.6.1-SNAPSHOT</version>
 
   <name>Vert.x Auth</name>
 
   <properties>
-    <stack.version>3.6.0</stack.version>
+    <stack.version>3.6.1-SNAPSHOT</stack.version>
     <doc.skip>true</doc.skip>
   </properties>
 

--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.0</version>
+    <version>3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htdigest/pom.xml
+++ b/vertx-auth-htdigest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htdigest/pom.xml
+++ b/vertx-auth-htdigest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htdigest/pom.xml
+++ b/vertx-auth-htdigest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htdigest/pom.xml
+++ b/vertx-auth-htdigest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htdigest/pom.xml
+++ b/vertx-auth-htdigest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.0</version>
+    <version>3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htdigest/pom.xml
+++ b/vertx-auth-htdigest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htdigest/pom.xml
+++ b/vertx-auth-htdigest/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htpasswd/pom.xml
+++ b/vertx-auth-htpasswd/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.0</version>
+    <version>3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htpasswd/pom.xml
+++ b/vertx-auth-htpasswd/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htpasswd/pom.xml
+++ b/vertx-auth-htpasswd/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htpasswd/pom.xml
+++ b/vertx-auth-htpasswd/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htpasswd/pom.xml
+++ b/vertx-auth-htpasswd/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htpasswd/pom.xml
+++ b/vertx-auth-htpasswd/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-htpasswd/pom.xml
+++ b/vertx-auth-htpasswd/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jdbc/pom.xml
+++ b/vertx-auth-jdbc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.0</version>
+    <version>3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jdbc/pom.xml
+++ b/vertx-auth-jdbc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jdbc/pom.xml
+++ b/vertx-auth-jdbc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jdbc/pom.xml
+++ b/vertx-auth-jdbc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jdbc/pom.xml
+++ b/vertx-auth-jdbc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jdbc/pom.xml
+++ b/vertx-auth-jdbc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jdbc/pom.xml
+++ b/vertx-auth-jdbc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.0</version>
+    <version>3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-jwt/pom.xml
+++ b/vertx-auth-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.0</version>
+    <version>3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.0</version>
+    <version>3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
@@ -51,7 +51,7 @@ public class OAuth2API {
     }
 
     final String url = path.charAt(0) == '/' ? config.getSite() + path : path;
-    LOG.info("Fetching URL: " + url);
+    LOG.debug("Fetching URL: " + url);
 
     // create a request
     final HttpClientRequest request = makeRequest(vertx, config, method, url, callback);
@@ -201,7 +201,7 @@ public class OAuth2API {
     final String xAcceptedOAuthScopes = reply.getHeader("X-Accepted-OAuth-Scopes");
 
     if (xOAuthScopes != null) {
-      LOG.debug("Received non-standard X-OAuth-Scopes: "+ xOAuthScopes);
+      LOG.trace("Received non-standard X-OAuth-Scopes: "+ xOAuthScopes);
       if (json.containsKey("scope")) {
         json.put("scope", json.getString("scope") + sep + xOAuthScopes);
       } else {
@@ -210,7 +210,7 @@ public class OAuth2API {
     }
 
     if (xAcceptedOAuthScopes != null) {
-      LOG.debug("Received non-standard X-Accepted-OAuth-Scopes: "+ xAcceptedOAuthScopes);
+      LOG.trace("Received non-standard X-Accepted-OAuth-Scopes: "+ xAcceptedOAuthScopes);
       json.put("acceptedScopes", xAcceptedOAuthScopes);
     }
   }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2ResponseImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2ResponseImpl.java
@@ -17,7 +17,7 @@ public class OAuth2ResponseImpl implements OAuth2Response {
 
 
   public OAuth2ResponseImpl(int statusCode, MultiMap headers, Buffer body) {
-    LOG.info("New response: statusCode: "+ statusCode );
+    LOG.debug("New response: statusCode: "+ statusCode );
     this.headers = headers;
     this.body = body;
     this.statusCode = statusCode;

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
@@ -39,7 +39,7 @@ import static io.vertx.ext.auth.oauth2.impl.OAuth2API.*;
 public class OAuth2TokenImpl extends OAuth2UserImpl {
 
   private static final Logger LOG = LoggerFactory.getLogger(OAuth2TokenImpl.class);
-  
+
   /**
    * Creates an AccessToken instance.
    */
@@ -78,7 +78,7 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
   @Override
   public OAuth2TokenImpl refresh(Handler<AsyncResult<Void>> handler) {
 
-    LOG.info("Refreshing AccessToken");
+    LOG.debug("Refreshing AccessToken");
 
     final JsonObject headers = new JsonObject();
     final OAuth2AuthProviderImpl provider = getProvider();

--- a/vertx-auth-shiro/pom.xml
+++ b/vertx-auth-shiro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/vertx-auth-shiro/pom.xml
+++ b/vertx-auth-shiro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.2</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/vertx-auth-shiro/pom.xml
+++ b/vertx-auth-shiro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/vertx-auth-shiro/pom.xml
+++ b/vertx-auth-shiro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/vertx-auth-shiro/pom.xml
+++ b/vertx-auth-shiro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.0</version>
+    <version>3.6.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/vertx-auth-shiro/pom.xml
+++ b/vertx-auth-shiro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/vertx-auth-shiro/pom.xml
+++ b/vertx-auth-shiro/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/vertx-jwt/pom.xml
+++ b/vertx-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.0</version>
+    <version>3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jwt/pom.xml
+++ b/vertx-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3</version>
+    <version>3.6.4-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jwt/pom.xml
+++ b/vertx-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.3-SNAPSHOT</version>
+    <version>3.6.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jwt/pom.xml
+++ b/vertx-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1</version>
+    <version>3.6.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jwt/pom.xml
+++ b/vertx-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2</version>
+    <version>3.6.3-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jwt/pom.xml
+++ b/vertx-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.2-SNAPSHOT</version>
+    <version>3.6.2</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/vertx-jwt/pom.xml
+++ b/vertx-jwt/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>vertx-auth</artifactId>
     <groupId>io.vertx</groupId>
-    <version>3.6.1-SNAPSHOT</version>
+    <version>3.6.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
vertx-auth-common does not export io.vertx.ext.auth.impl yet its required by ouath2.OSGi container Karaf hence complains when trying to resolve vertx-auth-oauth2 bundle in karaf.