### PR TITLE
enable export of impl package in vertx-auth-common for OSGI containers

### DIFF
--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -65,7 +65,7 @@
           Import-Package: \
             io.vertx.codegen.annotations;resolution:=optional,\
             *
-          -exportcontents: !*impl, !examples, *
+          -exportcontents: !examples, *
         ]]></bnd>
       </configuration>
     </plugin>


### PR DESCRIPTION
vertx-auth-oauth2 requires impl package from vertx-auth-common which apparently is not exported hence Karaf is unable to resolve the outh2 bundle.
