### PR TITLE
reuse `HttpClient` between oauth requests

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -30,8 +30,6 @@ import io.vertx.ext.jwt.JWT;
 import io.vertx.ext.auth.oauth2.*;
 import io.vertx.ext.auth.oauth2.impl.flow.*;
 
-import static io.vertx.ext.auth.oauth2.impl.OAuth2API.fetch;
-
 /**
  * @author Paulo Lopes
  */
@@ -42,12 +40,14 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, AuthProviderInternal 
   private final JWT jwt = new JWT();
 
   private final OAuth2Flow flow;
+  private final OAuth2API api;
 
   private OAuth2RBAC rbac;
 
   public OAuth2AuthProviderImpl(Vertx vertx, OAuth2ClientOptions config) {
     this.vertx = vertx;
     this.config = config;
+    this.api = new OAuth2API(vertx, config);
 
     if (config.getPubSecKeys() != null) {
       for (PubSecKeyOptions pubSecKey : config.getPubSecKeys()) {
@@ -90,9 +90,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, AuthProviderInternal 
     // specify preferred accepted content type
     headers.put("Accept", "application/json");
 
-    fetch(
-      vertx,
-      config,
+    api.fetch(
       HttpMethod.GET,
       config.getJwkPath(),
       headers,

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
@@ -39,6 +39,8 @@ import static io.vertx.ext.auth.oauth2.impl.OAuth2API.*;
 public class OAuth2TokenImpl extends OAuth2UserImpl {
 
   private static final Logger LOG = LoggerFactory.getLogger(OAuth2TokenImpl.class);
+
+  private OAuth2API api;
   
   /**
    * Creates an AccessToken instance.
@@ -107,9 +109,7 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
     // specify preferred accepted accessToken type
     headers.put("Accept", "application/json,application/x-www-form-urlencoded;q=0.9");
 
-    OAuth2API.fetch(
-      provider.getVertx(),
-      config,
+    getApi().fetch(
       HttpMethod.POST,
       config.getTokenPath(),
       headers,
@@ -212,9 +212,7 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
       // specify preferred accepted accessToken type
       headers.put("Accept", "application/json,application/x-www-form-urlencoded;q=0.9");
 
-      OAuth2API.fetch(
-        provider.getVertx(),
-        config,
+      getApi().fetch(
         HttpMethod.POST,
         config.getRevocationPath(),
         headers,
@@ -283,9 +281,7 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
     // specify preferred accepted accessToken type
     headers.put("Accept", "application/json,application/x-www-form-urlencoded;q=0.9");
 
-    OAuth2API.fetch(
-      provider.getVertx(),
-      config,
+    getApi().fetch(
       HttpMethod.POST,
       config.getLogoutPath(),
       headers,
@@ -329,9 +325,7 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
     // specify preferred accepted accessToken type
     headers.put("Accept", "application/json,application/x-www-form-urlencoded;q=0.9");
 
-    OAuth2API.fetch(
-      provider.getVertx(),
-      config,
+    getApi().fetch(
       HttpMethod.POST,
       config.getIntrospectionPath(),
       headers,
@@ -506,9 +500,7 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
     // specify preferred accepted accessToken type
     headers.put("Accept", "application/json,application/x-www-form-urlencoded;q=0.9");
 
-    OAuth2API.fetch(
-      provider.getVertx(),
-      config,
+    getApi().fetch(
       HttpMethod.GET,
       path,
       headers,
@@ -564,9 +556,7 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
     // add the access token
     headers.put("Authorization", "Bearer " + opaqueAccessToken());
 
-    OAuth2API.fetch(
-      provider.getVertx(),
-      config,
+    getApi().fetch(
       method,
       resource,
       headers,
@@ -580,5 +570,13 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
         callback.handle(Future.succeededFuture(fetch.result()));
       });
     return this;
+  }
+
+  private OAuth2API getApi() {
+    if (api == null) {
+      OAuth2AuthProviderImpl p = getProvider();
+      api = new OAuth2API(p.getVertx(), p.getConfig());
+    }
+    return api;
   }
 }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/flow/AbstractOAuth2Flow.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/flow/AbstractOAuth2Flow.java
@@ -24,6 +24,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
 import io.vertx.ext.auth.oauth2.OAuth2Response;
+import io.vertx.ext.auth.oauth2.impl.OAuth2API;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Base64;
@@ -37,10 +38,12 @@ abstract class AbstractOAuth2Flow implements OAuth2Flow {
 
   protected final Vertx vertx;
   protected final OAuth2ClientOptions config;
+  protected final OAuth2API api;
 
   AbstractOAuth2Flow(Vertx vertx, OAuth2ClientOptions config) {
     this.vertx = vertx;
     this.config = config;
+    this.api = new OAuth2API(vertx, config);
   }
 
   static void throwIfNull(String key, Object value) throws IllegalArgumentException {
@@ -82,9 +85,7 @@ abstract class AbstractOAuth2Flow implements OAuth2Flow {
     // specify preferred accepted content type
     headers.put("Accept", "application/json,application/x-www-form-urlencoded;q=0.9");
 
-    fetch(
-      vertx,
-      config,
+    api.fetch(
       HttpMethod.POST,
       config.getTokenPath(),
       headers,

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/flow/AuthJWTImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/flow/AuthJWTImpl.java
@@ -62,9 +62,7 @@ public class AuthJWTImpl extends AbstractOAuth2Flow implements OAuth2Flow {
       .put("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer")
       .put("assertion", provider.getJWT().sign(params, provider.getConfig().getJWTOptions()));
 
-    fetch(
-      provider.getVertx(),
-      provider.getConfig(),
+    api.fetch(
       HttpMethod.POST,
       provider.getConfig().getTokenPath(),
       new JsonObject().put("Content-Type", "application/x-www-form-urlencoded"),

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/OpenIDConnectAuth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/OpenIDConnectAuth.java
@@ -11,8 +11,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
 import io.vertx.ext.auth.oauth2.OAuth2Response;
-
-import static io.vertx.ext.auth.oauth2.impl.OAuth2API.*;
+import io.vertx.ext.auth.oauth2.impl.OAuth2API;
 
 /**
  * Simplified factory to create an {@link io.vertx.ext.auth.oauth2.OAuth2Auth} for OpenID Connect.
@@ -39,7 +38,8 @@ public interface OpenIDConnectAuth {
       return;
     }
 
-    final HttpClientRequest request = makeRequest(vertx, config, HttpMethod.GET, config.getSite() + "/.well-known/openid-configuration", res -> {
+    final OAuth2API api = new OAuth2API(vertx, config);
+    final HttpClientRequest request = api.makeRequest(HttpMethod.GET, config.getSite() + "/.well-known/openid-configuration", res -> {
       if (res.failed()) {
         handler.handle(Future.failedFuture(res.cause()));
         return;


### PR DESCRIPTION
Currently, a new `HttpClient` is initialized and closed again for *every* oauth request. This causes a new connection to be established for *every request* which can have a significant impact on performance (see [this vertx-group conversation](https://groups.google.com/forum/#!msg/vertx/IrC5pFqj1J8/E51_8MH-GgAJ)). This PR changes the `OAuth2API` class to keep a reference to the `HttpClient` that is re-used between requests.