### PR TITLE
Issue 277 - Disable validation of refresh token

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2UserImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2UserImpl.java
@@ -69,7 +69,7 @@ public abstract class OAuth2UserImpl extends AbstractUser implements AccessToken
             principal.put("expires_at", exp * 1000);
           }
         }
-        refreshToken = decodeToken("refresh_token");
+        refreshToken = decodeToken("refresh_token", true);
         idToken = decodeToken("id_token");
         // rebuild cache
         String scope = principal.getString("scope");


### PR DESCRIPTION
To avoid any breaking changes. I have only disabled validation of refresh token. Means, decoded refresh token is still available, but, signature is not validated.