### PR TITLE
Use HTTPS instead of HTTP for Salesforce site URL

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/SalesforceAuth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/SalesforceAuth.java
@@ -38,7 +38,7 @@ public interface SalesforceAuth extends OpenIDConnectAuth {
     return
       OAuth2Auth.create(vertx, new OAuth2ClientOptions(httpClientOptions)
         .setFlow(OAuth2FlowType.AUTH_CODE)
-        .setSite("http://login.salesforce.com")
+        .setSite("https://login.salesforce.com")
         .setTokenPath("/services/oauth2/token")
         .setAuthorizationPath("/services/oauth2/authorize")
         .setScopeSeparator("+")


### PR DESCRIPTION
Otherwise there will be an error on the callback handler when attempting to access:
http://login.salesforce.com/services/oauth2/token