### PR TITLE
Mark providers and user implementation with a FQCN

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/AuthProvider.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/AuthProvider.java
@@ -30,7 +30,16 @@ import io.vertx.core.json.JsonObject;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
+@FunctionalInterface
 public interface AuthProvider {
+
+  /**
+   * The FQCN for this provider. This is needed in order to match serialized user objects to providers.
+   * @return FQCN of the implementation interface.
+   */
+  default String id() {
+    return "<none>";
+  }
 
   /**
    * Authenticate a user.

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/ChainAuth.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/ChainAuth.java
@@ -37,6 +37,14 @@ public interface ChainAuth extends AuthProvider {
 
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  default String id() {
+    return ChainAuth.class.getName();
+  }
+
+  /**
    * Appends a auth provider to the chain.
    *
    * @param other auth provider

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/User.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/User.java
@@ -84,6 +84,14 @@ public interface User {
    */
   JsonObject principal();
 
+
+  /**
+   * The configured provider FQCN for this User object. This is useful to match User objects with existing providers.
+   *
+   * @return FQCN.
+   */
+  String providerId();
+
   /**
    * Set the auth provider for the User. This is typically used to reattach a detached User with an AuthProvider, e.g.
    * after it has been deserialized.

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/ChainAuthTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/ChainAuthTest.java
@@ -96,6 +96,12 @@ public class ChainAuthTest extends VertxTestBase {
 
   private User createUser(final JsonObject principal) {
     return new User() {
+
+      @Override
+      public String providerId() {
+        return "dummy";
+      }
+
       @Override
       public User isAuthorized(String authority, Handler<AsyncResult<Boolean>> resultHandler) {
         return null;

--- a/vertx-auth-htdigest/src/main/java/io/vertx/ext/auth/htdigest/HtdigestAuth.java
+++ b/vertx-auth-htdigest/src/main/java/io/vertx/ext/auth/htdigest/HtdigestAuth.java
@@ -54,6 +54,14 @@ public interface HtdigestAuth extends AuthProvider {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  default String id() {
+    return HtdigestAuth.class.getName();
+  }
+
+  /**
    * Return the currently used realm
    *
    * @return  the realm

--- a/vertx-auth-htdigest/src/main/java/io/vertx/ext/auth/htdigest/impl/HtdigestUser.java
+++ b/vertx-auth-htdigest/src/main/java/io/vertx/ext/auth/htdigest/impl/HtdigestUser.java
@@ -21,6 +21,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.htdigest.HtdigestAuth;
 
 /**
  * @author Paulo Lopes
@@ -33,6 +34,11 @@ public class HtdigestUser implements User {
   public HtdigestUser(String username, String realm) {
     this.username = username;
     this.realm = realm;
+  }
+
+  @Override
+  public String providerId() {
+    return HtdigestAuth.class.getName();
   }
 
   @Override

--- a/vertx-auth-htpasswd/src/main/java/io/vertx/ext/auth/htpasswd/HtpasswdAuth.java
+++ b/vertx-auth-htpasswd/src/main/java/io/vertx/ext/auth/htpasswd/HtpasswdAuth.java
@@ -36,4 +36,11 @@ public interface HtpasswdAuth extends AuthProvider {
     return new HtpasswdAuthImpl(vertx, htpasswdAuthOptions);
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  default String id() {
+    return HtpasswdAuth.class.getName();
+  }
 }

--- a/vertx-auth-htpasswd/src/main/java/io/vertx/ext/auth/htpasswd/impl/HtpasswdUser.java
+++ b/vertx-auth-htpasswd/src/main/java/io/vertx/ext/auth/htpasswd/impl/HtpasswdUser.java
@@ -6,6 +6,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.htpasswd.HtpasswdAuth;
 
 /**
  * @author Neven Radovanović
@@ -21,6 +22,11 @@ public class HtpasswdUser extends AbstractUser {
   @Override
   protected void doIsPermitted(String permission, Handler<AsyncResult<Boolean>> resultHandler) {
     resultHandler.handle(Future.succeededFuture(false));
+  }
+
+  @Override
+  public String providerId() {
+    return HtpasswdAuth.class.getName();
   }
 
   @Override

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuth.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuth.java
@@ -68,6 +68,14 @@ public interface JDBCAuth extends AuthProvider {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  default String id() {
+    return JDBCAuth.class.getName();
+  }
+
+  /**
    * Set the authentication query to use. Use this if you want to override the default authentication query.
    * @param authenticationQuery  the authentication query
    * @return  a reference to this for fluency

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCAuthImpl.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCAuthImpl.java
@@ -19,7 +19,6 @@ package io.vertx.ext.auth.jdbc.impl;
 import io.vertx.core.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jdbc.JDBCAuth;
 import io.vertx.ext.auth.jdbc.JDBCHashStrategy;
@@ -32,7 +31,7 @@ import java.util.function.Consumer;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
-public class JDBCAuthImpl implements AuthProvider, JDBCAuth {
+public class JDBCAuthImpl implements JDBCAuth {
 
   private JDBCClient client;
   private String authenticateQuery = DEFAULT_AUTHENTICATE_QUERY;

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCUser.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCUser.java
@@ -24,6 +24,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.jdbc.JDBCAuth;
 
 import java.nio.charset.StandardCharsets;
 
@@ -46,6 +47,11 @@ public class JDBCUser extends AbstractUser {
     this.username = username;
     this.authProvider = authProvider;
     this.rolePrefix = rolePrefix;
+  }
+
+  @Override
+  public String providerId() {
+    return JDBCAuth.class.getName();
   }
 
   @Override

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/JWTAuth.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/JWTAuth.java
@@ -44,6 +44,14 @@ public interface JWTAuth extends AuthProvider {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  default String id() {
+    return JWTAuth.class.getName();
+  }
+
+  /**
    * Generate a new JWT token.
    *
    * @param claims Json with user defined claims for a list of official claims

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTUser.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTUser.java
@@ -25,6 +25,7 @@ import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.jwt.JWTAuth;
 
 import java.nio.charset.StandardCharsets;
 
@@ -42,6 +43,11 @@ public class JWTUser extends AbstractUser {
     // required if the object is serialized, however this is not a good idea
     // because JWT are supposed to be used in stateless environments
     log.info("You are probably serializing the JWT User, JWT are supposed to be used in stateless servers!");
+  }
+
+  @Override
+  public String providerId() {
+    return JWTAuth.class.getName();
   }
 
   public JWTUser(JsonObject jwtToken, String permissionsClaimKey) {

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoAuth.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoAuth.java
@@ -154,6 +154,14 @@ public interface MongoAuth extends AuthProvider {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  default String id() {
+    return MongoAuth.class.getName();
+  }
+
+  /**
    * Set the name of the collection to be used. Defaults to {@link #DEFAULT_COLLECTION_NAME}
    *
    * @param collectionName

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthImpl.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthImpl.java
@@ -35,6 +35,7 @@ import java.util.List;
  * @author mremme
  */
 public class MongoAuthImpl implements MongoAuth {
+
   private static final Logger log = LoggerFactory.getLogger(MongoAuthImpl.class);
   private MongoClient mongoClient;
   private String usernameField = DEFAULT_USERNAME_FIELD;

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUser.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUser.java
@@ -49,6 +49,11 @@ public class MongoUser extends AbstractUser {
     this.mongoAuth = mongoAuth;
   }
 
+  @Override
+  public String providerId() {
+    return MongoAuth.class.getName();
+  }
+
   /*
    * (non-Javadoc)
    * 

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Auth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Auth.java
@@ -53,6 +53,14 @@ public interface OAuth2Auth extends AuthProvider {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  default String id() {
+    return OAuth2Auth.class.getName();
+  }
+
+  /**
    * Generate a redirect URL to the authN/Z backend. It only applies to auth_code flow.
    */
   String authorizeURL(JsonObject params);

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
@@ -58,6 +58,11 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
   }
 
   @Override
+  public String providerId() {
+    return OAuth2Auth.class.getName();
+  }
+
+  @Override
   public AccessToken setTrustJWT(boolean trust) {
     // refresh the tokens
     accessToken = decodeToken("access_token", trust);

--- a/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/ShiroAuth.java
+++ b/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/ShiroAuth.java
@@ -16,10 +16,10 @@
 
 package io.vertx.ext.auth.shiro;
 
+import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.auth.shiro.impl.ShiroAuthProviderImpl;
 import org.apache.shiro.realm.Realm;
@@ -59,10 +59,19 @@ public interface ShiroAuth extends AuthProvider {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  @Override
+  default String id() {
+    return ShiroAuth.class.getName();
+  }
+
+  /**
    * Set the role prefix to distinguish from permissions when checking for isPermitted requests.
    * @param rolePrefix a Prefix e.g.: "role:"
    * @return a reference to this for fluency
    */
+  @Fluent
   ShiroAuth setRolePrefix(String rolePrefix);
 
 }

--- a/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/ShiroUser.java
+++ b/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/ShiroUser.java
@@ -23,6 +23,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.shiro.ShiroAuth;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.subject.SimplePrincipalCollection;
@@ -54,6 +55,11 @@ public class ShiroUser extends AbstractUser {
   }
 
   public ShiroUser() {
+  }
+
+  @Override
+  public String providerId() {
+    return ShiroAuth.class.getName();
   }
 
   @Override


### PR DESCRIPTION
In a multi tenant scenario (where multiple providers are active in the same application, when user objects are deserialized over the wire there's no way to relate the source user to the original provider.

This PR will address this by adding the necessary metadata to the user object and provider so and the session level they can be matched.