### PR TITLE
Manage scope claim

### DIFF
--- a/vertx-auth-jwt/src/test/java/io/vertx/ext/auth/test/jwt/JWTAuthProviderTest.java
+++ b/vertx-auth-jwt/src/test/java/io/vertx/ext/auth/test/jwt/JWTAuthProviderTest.java
@@ -284,6 +284,137 @@ public class JWTAuthProviderTest extends VertxTestBase {
   }
 
   @Test
+  public void testGoodScopes() {
+    //JWT is valid because required scopes "a" & "b" are well included in the access_token.
+    authProvider = JWTAuth.create(vertx, getConfig().setJWTOptions(
+      new JWTOptions()
+        .addScope("a")
+        .addScope("b")));
+
+    JsonObject payload = new JsonObject()
+      .put("sub", "Paulo");
+
+    final String token = authProvider.generateToken(payload,
+      new JWTOptions().addScope("a").addScope("b").addScope("c"));
+
+    assertNotNull(token);
+
+    JsonObject authInfo = new JsonObject()
+      .put("jwt", token);
+
+    authProvider.authenticate(authInfo, onSuccess(res -> {
+      assertNotNull(res);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testGoodScopesWithDelimiter() {
+    //JWT is valid because required scopes "a" & "b" are well included in the access_token.
+    authProvider = JWTAuth.create(vertx, getConfig().setJWTOptions(
+      new JWTOptions()
+        .addScope("a")
+        .addScope("b")
+        .withScopeDelimiter(",")));
+
+    JsonObject payload = new JsonObject()
+      .put("sub", "Paulo");
+
+    final String token = authProvider.generateToken(payload,
+      new JWTOptions().addScope("a").addScope("b").addScope("c").withScopeDelimiter(","));
+
+    assertNotNull(token);
+
+    JsonObject authInfo = new JsonObject()
+      .put("jwt", token);
+
+    authProvider.authenticate(authInfo, onSuccess(res -> {
+      assertNotNull(res);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testGoodScopesWithDefaultDelimiter() {
+    //JWT is valid because required scopes "a" & "b" are well included in the access_token.
+    authProvider = JWTAuth.create(vertx, getConfig().setJWTOptions(
+      new JWTOptions()
+        .addScope("a")
+        .addScope("b")));
+
+    JsonObject payload = new JsonObject()
+      .put("sub", "Paulo");
+
+    final String token = authProvider.generateToken(payload,
+      new JWTOptions().addScope("a").addScope("b").addScope("c").withScopeDelimiter(" "));
+
+    assertNotNull(token);
+
+    JsonObject authInfo = new JsonObject()
+      .put("jwt", token);
+
+    authProvider.authenticate(authInfo, onSuccess(res -> {
+      assertNotNull(res);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testBadScopes() {
+    //JWT is not valid because the required scopes "d" is not included in the access_token.
+    authProvider = JWTAuth.create(vertx, getConfig().setJWTOptions(
+      new JWTOptions()
+        .addScope("b")
+        .addScope("d")));
+
+    JsonObject payload = new JsonObject()
+      .put("sub", "Paulo");
+
+    final String token = authProvider.generateToken(payload,
+      new JWTOptions().addScope("a").addScope("b").addScope("c"));
+
+    assertNotNull(token);
+
+    JsonObject authInfo = new JsonObject()
+      .put("jwt", token);
+
+    authProvider.authenticate(authInfo, onFailure(thr -> {
+      assertNotNull(thr);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testBadScopesFormat() {
+    //JWT is not valid because the authProvider is expecting an array of scope while the JWT has a string scope.
+    authProvider = JWTAuth.create(vertx, getConfig().setJWTOptions(
+      new JWTOptions()
+        .addScope("a")
+        .addScope("b")));
+
+    JsonObject payload = new JsonObject()
+      .put("sub", "Paulo");
+
+    final String token = authProvider.generateToken(payload,
+      new JWTOptions().addScope("a").addScope("b").addScope("c").withScopeDelimiter(","));
+
+    assertNotNull(token);
+
+    JsonObject authInfo = new JsonObject()
+      .put("jwt", token);
+
+    authProvider.authenticate(authInfo, onFailure(thr -> {
+      assertNotNull(thr);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
   public void testGenerateNewTokenES256() {
     authProvider = JWTAuth.create(vertx, new JWTAuthOptions()
       .setKeyStore(new KeyStoreOptions()

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/AccessToken.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/AccessToken.java
@@ -41,6 +41,11 @@ public interface AccessToken extends User {
   boolean expired();
 
   /**
+   * Check if the access token own the required scopes to access to the resource.
+   */
+  boolean isScopeGranted();
+
+  /**
    * The Access Token if present parsed as a JsonObject
    * @return JSON
    */

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -224,6 +224,10 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, AuthProviderInternal 
             resultHandler.handle(Future.failedFuture("Expired token"));
             return;
           }
+          if (!oauth2Token.isScopeGranted()) {
+            resultHandler.handle(Future.failedFuture("Missing required scopes token"));
+            return;
+          }
           // return self
           resultHandler.handle(Future.succeededFuture(oauth2Token));
         });
@@ -232,6 +236,8 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, AuthProviderInternal 
         // the token might be valid, but expired
         if (oauth2Token.expired()) {
           resultHandler.handle(Future.failedFuture("Expired Token"));
+        } else if (!oauth2Token.isScopeGranted()){
+          resultHandler.handle(Future.failedFuture("Missing required scopes token"));
         } else {
           resultHandler.handle(Future.succeededFuture(oauth2Token));
         }

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/Oauth2TokenScopeTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/Oauth2TokenScopeTest.java
@@ -1,0 +1,282 @@
+package io.vertx.ext.auth.test.oauth2;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.PubSecKeyOptions;
+import io.vertx.ext.auth.oauth2.AccessToken;
+import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
+import io.vertx.ext.auth.oauth2.OAuth2FlowType;
+import io.vertx.ext.jwt.JWTOptions;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.CountDownLatch;
+
+import static io.vertx.ext.auth.oauth2.impl.OAuth2API.queryToJSON;
+
+public class Oauth2TokenScopeTest extends VertxTestBase {
+
+  private final static String JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InNjb3BlQSBzY29wZUIgc2NvcGVDIiwiZXhwIjo5OTk5OTk5OTk5LCJuYmYiOjAsImlhdCI6MTQ2NDkwNjY3MSwic3ViIjoiZjE4ODhmNGQtNTE3Mi00MzU5LWJlMGMtYWYzMzg1MDVkODZjIn0.7aJYjGVe4YfdnYTlQH_FYhRCjvctcE7DtWwzxXrbLmM";
+
+  private OAuth2Auth oauth2;
+  private HttpServer server;
+  private JsonObject config;
+  private OAuth2ClientOptions oauthConfig;
+  private JsonObject fixtureIntrospect;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    fixtureIntrospect = new JsonObject(
+      "{" +
+        "  \"active\": true," +
+        "  \"scope\": \"scopeA scopeB\"," +
+        "  \"client_id\": \"client-id\"," +
+        "  \"username\": \"username\"," +
+        "  \"token_type\": \"bearer\"," +
+        "  \"exp\": 99999999999," +
+        "  \"iat\": 7200," +
+        "  \"nbf\": 7200" +
+        "}");
+
+    oauthConfig = new OAuth2ClientOptions()
+      .setFlow(OAuth2FlowType.AUTH_CODE)
+      .setClientID("client-id")
+      .setClientSecret("client-secret")
+      .setSite("http://localhost:8080");
+
+    oauth2 = OAuth2Auth.create(vertx, oauthConfig);
+
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    server = vertx.createHttpServer().requestHandler(req -> {
+      if (req.method() == HttpMethod.POST && "/oauth/introspect".equals(req.path())) {
+          req.setExpectMultipart(true).bodyHandler(buffer -> {
+            try {
+              JsonObject body = queryToJSON(buffer.toString());
+              assertEquals(config.getString("token"), body.getString("token"));
+              // conditional test for token_type_hint
+              if (config.containsKey("token_type_hint")) {
+                assertEquals(config.getString("token_type_hint"), body.getString("token_type_hint"));
+              }
+            } catch (UnsupportedEncodingException e) {
+              fail(e);
+            }
+            req.response().putHeader("Content-Type", "application/json").end(fixtureIntrospect.encode());
+          });
+      } else {
+        req.response().setStatusCode(400).end();
+      }
+    }).listen(8080, ready -> {
+      if (ready.failed()) {
+        throw new RuntimeException(ready.cause());
+      }
+      // ready
+      latch.countDown();
+    });
+
+    latch.await();
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    server.close();
+    super.tearDown();
+  }
+
+  /**
+   * Token scopes are checked and must be valid.
+   * Scopes are retrieved from the JWT itself.
+   * JWT generated in HS256 with vertx as shared secret.
+   */
+  @Test
+  public void tokenIsValid() {
+    config = new JsonObject()
+      .put("token_type", "Bearer")
+      .put("access_token", JWT)
+      .put("token", JWT);
+
+    oauthConfig
+      .addPubSecKey(new PubSecKeyOptions().setAlgorithm("HS256").setSecretKey("vertx").setSymmetric(true))
+      .setJWTOptions(new JWTOptions().addScope("scopeA").addScope("scopeB"));
+
+    oauth2 = OAuth2Auth.create(vertx, oauthConfig);
+
+    oauth2.authenticate(config, res -> {
+      if (res.failed()) {
+        fail(res.cause().getMessage());
+      } else {
+        AccessToken token = (AccessToken) res.result();
+        assertFalse(token.expired());
+        assertTrue(token.isScopeGranted());
+        testComplete();
+      }
+    });
+    await();
+  }
+
+  /**
+   * Token scopes are checked and must be valid.
+   * Scopes are retrieved through the token introspection.
+   */
+  @Test
+  public void tokenIsValid_withIntrospection() {
+    final String opaqueToken = "opaqueToken";
+
+    config = new JsonObject()
+      .put("token_type", "Bearer")
+      .put("access_token", opaqueToken)
+      .put("token", opaqueToken);
+
+    oauthConfig
+      .setIntrospectionPath("/oauth/introspect")
+      .setJWTOptions(new JWTOptions().addScope("scopeA").addScope("scopeB"));
+
+    oauth2 = OAuth2Auth.create(vertx, oauthConfig);
+
+    oauth2.authenticate(config, res -> {
+      if (res.failed()) {
+        fail(res.cause().getMessage());
+      } else {
+        AccessToken token = (AccessToken) res.result();
+        assertFalse(token.expired());
+        assertTrue(token.isScopeGranted());
+        testComplete();
+      }
+    });
+    await();
+  }
+
+  /**
+   * Token scopes are checked and scopeX is missing.
+   * Scopes are retrieved from the JWT itself.
+   * JWT generated in HS256 with vertx as shared secret.
+   */
+  @Test
+  public void tokenIsNotValid() {
+    config = new JsonObject()
+      .put("token_type", "Bearer")
+      .put("access_token", JWT)
+      .put("token", JWT);
+
+    oauthConfig
+      .addPubSecKey(new PubSecKeyOptions().setAlgorithm("HS256").setSecretKey("vertx").setSymmetric(true))
+      .setJWTOptions(new JWTOptions().addScope("scopeX").addScope("scopeB"));
+
+    oauth2 = OAuth2Auth.create(vertx, oauthConfig);
+
+    oauth2.authenticate(config, res -> {
+      if (res.failed()) {
+        assertEquals("Missing required scopes token",res.cause().getMessage());
+        testComplete();
+      } else {
+        fail("Test should have failed");
+      }
+    });
+    await();
+  }
+
+  /**
+   * Token scopes are checked and scopeX is missing.
+   * Scopes are retrieved through the token introspection.
+   */
+  @Test
+  public void tokenIsNotValid_withIntrospection() {
+    final String opaqueToken = "opaqueToken";
+
+    config = new JsonObject()
+      .put("token_type", "Bearer")
+      .put("access_token", opaqueToken)
+      .put("token", opaqueToken);
+
+    oauthConfig
+      .setIntrospectionPath("/oauth/introspect")
+      .setJWTOptions(new JWTOptions().addScope("scopeX").addScope("scopeB"));
+
+    oauth2 = OAuth2Auth.create(vertx, oauthConfig);
+
+    oauth2.authenticate(config, res -> {
+      if (res.failed()) {
+        assertEquals("Missing required scopes token",res.cause().getMessage());
+        testComplete();
+      } else {
+        fail("Test should have failed");
+      }
+    });
+    await();
+  }
+
+  /**
+   * Scopes are not available through the token introspection.
+   * Scopes check must not be performed / throw an error.
+   */
+  @Test
+  public void shouldNotFailWhenNoIntrospectionScope() {
+    final String opaqueToken = "opaqueToken";
+
+    this.fixtureIntrospect = new JsonObject(
+      "{" +
+        "  \"active\": true," +
+        //"  \"scope\": \"scopeA scopeB\"," +
+        "  \"client_id\": \"client-id\"," +
+        "  \"username\": \"username\"," +
+        "  \"token_type\": \"bearer\"," +
+        "  \"exp\": 99999999999," +
+        "  \"iat\": 7200," +
+        "  \"nbf\": 7200" +
+        "}");
+
+    config = new JsonObject()
+      .put("token_type", "Bearer")
+      .put("access_token", opaqueToken)
+      .put("token", opaqueToken);
+
+    oauthConfig
+      .setIntrospectionPath("/oauth/introspect")
+      .setJWTOptions(new JWTOptions().addScope("scopeX").addScope("scopeB"));
+
+    oauth2 = OAuth2Auth.create(vertx, oauthConfig);
+
+    oauth2.authenticate(config, res -> {
+      if (res.failed()) {
+        fail("Test should have not failed");
+      } else {
+        AccessToken token = (AccessToken) res.result();
+        assertEquals("username",token.principal().getValue("username"));
+        assertNull(token.principal().getValue("scope"));
+        testComplete();
+      }
+    });
+    await();
+  }
+
+  /**
+   * Scopes are available into the token but no scopes requirement is set.
+   */
+  @Test
+  public void shouldNotFailWhenNoScopeRequired() {
+    config = new JsonObject()
+      .put("token_type", "Bearer")
+      .put("access_token", JWT)
+      .put("token", JWT);
+
+    oauthConfig
+      .addPubSecKey(new PubSecKeyOptions().setAlgorithm("HS256").setSecretKey("vertx").setSymmetric(true));
+
+    oauth2 = OAuth2Auth.create(vertx, oauthConfig);
+
+    oauth2.authenticate(config, res -> {
+      if (res.failed()) {
+        fail("Test should have not failed");
+      } else {
+        AccessToken token = (AccessToken) res.result();
+        testComplete();
+      }
+    });
+    await();
+  }
+}

--- a/vertx-jwt/src/main/generated/io/vertx/ext/jwt/JWTOptionsConverter.java
+++ b/vertx-jwt/src/main/generated/io/vertx/ext/jwt/JWTOptionsConverter.java
@@ -83,6 +83,16 @@ public class JWTOptionsConverter {
             obj.setPermissions(list);
           }
           break;
+        case "scopes":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setScopes(list);
+          }
+          break;
         case "subject":
           if (member.getValue() instanceof String) {
             obj.setSubject((String)member.getValue());
@@ -119,6 +129,11 @@ public class JWTOptionsConverter {
       JsonArray array = new JsonArray();
       obj.getPermissions().forEach(item -> array.add(item));
       json.put("permissions", array);
+    }
+    if (obj.getScopes() != null) {
+      JsonArray array = new JsonArray();
+      obj.getScopes().forEach(item -> array.add(item));
+      json.put("scopes", array);
     }
     if (obj.getSubject() != null) {
       json.put("subject", obj.getSubject());

--- a/vertx-jwt/src/main/generated/io/vertx/ext/jwt/JWTOptionsConverter.java
+++ b/vertx-jwt/src/main/generated/io/vertx/ext/jwt/JWTOptionsConverter.java
@@ -83,16 +83,6 @@ public class JWTOptionsConverter {
             obj.setPermissions(list);
           }
           break;
-        case "scopes":
-          if (member.getValue() instanceof JsonArray) {
-            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
-            ((Iterable<Object>)member.getValue()).forEach( item -> {
-              if (item instanceof String)
-                list.add((String)item);
-            });
-            obj.setScopes(list);
-          }
-          break;
         case "subject":
           if (member.getValue() instanceof String) {
             obj.setSubject((String)member.getValue());
@@ -129,11 +119,6 @@ public class JWTOptionsConverter {
       JsonArray array = new JsonArray();
       obj.getPermissions().forEach(item -> array.add(item));
       json.put("permissions", array);
-    }
-    if (obj.getScopes() != null) {
-      JsonArray array = new JsonArray();
-      obj.getScopes().forEach(item -> array.add(item));
-      json.put("scopes", array);
     }
     if (obj.getSubject() != null) {
       json.put("subject", obj.getSubject());

--- a/vertx-jwt/src/main/java/io/vertx/ext/jwt/JWT.java
+++ b/vertx-jwt/src/main/java/io/vertx/ext/jwt/JWT.java
@@ -289,6 +289,14 @@ public final class JWT {
       }
     }
 
+    if(options.getScopes() != null && options.getScopes().size() >= 1) {
+      if(options.hasScopeDelimiter()) {
+        payload.put("scope", String.join(options.getScopeDelimiter(), options.getScopes()));
+      } else {
+        payload.put("scope", new JsonArray(options.getScopes()));
+      }
+    }
+
     if (options.getIssuer() != null) {
       payload.put("iss", options.getIssuer());
     }

--- a/vertx-jwt/src/main/java/io/vertx/ext/jwt/JWT.java
+++ b/vertx-jwt/src/main/java/io/vertx/ext/jwt/JWT.java
@@ -15,6 +15,7 @@
  */
 package io.vertx.ext.jwt;
 
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.impl.logging.Logger;
@@ -27,6 +28,8 @@ import java.security.*;
 import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * JWT and JWS implementation draft-ietf-oauth-json-web-token-32.
@@ -253,6 +256,46 @@ public final class JWT {
     }
 
     return false;
+  }
+
+  /**
+   * Scope claim are used to grant access to a specific resource.
+   * They are included into the JWT when the user consent access to the resource,
+   * or sometimes without user consent (bypass approval).
+   * @param jwt JsonObject decoded json web token value.
+   * @param options JWTOptions coming from the provider.
+   * @return true if required scopes are into the JWT.
+   */
+  public boolean isScopeGranted(JsonObject jwt, JWTOptions options) {
+
+    if(jwt == null) {
+      return false;
+    }
+
+    if(options.getScopes() == null || options.getScopes().isEmpty()) {
+      return true; // no scopes to check
+    }
+
+    if(jwt.getValue("scope") == null) {
+      throw new RuntimeException("Invalid JWT: scope claim is required");
+    }
+
+    JsonArray target;
+    if (jwt.getValue("scope") instanceof String) {
+      target = new JsonArray(
+        Stream.of(jwt.getString("scope")
+          .split(options.getScopeDelimiter()))
+          .collect(Collectors.toList())
+      );
+    } else {
+      target = jwt.getJsonArray("scope");
+    }
+
+    if(!target.getList().containsAll(options.getScopes())) {
+      throw new RuntimeException("Invalid JWT scopes expected: " + Json.encode(options.getScopes()));
+    }
+
+    return true;
   }
 
   public String sign(JsonObject payload, JWTOptions options) {

--- a/vertx-jwt/src/main/java/io/vertx/ext/jwt/JWTOptions.java
+++ b/vertx-jwt/src/main/java/io/vertx/ext/jwt/JWTOptions.java
@@ -11,6 +11,7 @@ import java.util.List;
 public class JWTOptions {
 
   private static final JsonObject EMPTY = new JsonObject(Collections.emptyMap());
+  private static final String DEFAULT_SCOPE_DELIMITER = " ";
 
   private int leeway = 0;
   private boolean ignoreExpiration;
@@ -22,6 +23,8 @@ public class JWTOptions {
   private String issuer;
   private String subject;
   private List<String> permissions;
+  private List<String> scopes;
+  private String scopeDelimiter;
 
   public JWTOptions() {
 
@@ -158,5 +161,35 @@ public class JWTOptions {
 
   public List<String> getPermissions() {
     return permissions;
+  }
+
+  public JWTOptions setScopes(List<String> scopes) {
+    this.scopes = scopes;
+    return this;
+  }
+
+  public JWTOptions addScope(String scope) {
+    if (this.scopes == null) {
+      this.scopes = new ArrayList<>();
+    }
+    this.scopes.add(scope);
+    return this;
+  }
+
+  public List<String> getScopes() {
+    return scopes;
+  }
+
+  public String getScopeDelimiter() {
+    return scopeDelimiter!=null?scopeDelimiter:DEFAULT_SCOPE_DELIMITER;
+  }
+
+  public JWTOptions withScopeDelimiter(String scopeDelimiter) {
+    this.scopeDelimiter = scopeDelimiter;
+    return this;
+  }
+
+  public boolean hasScopeDelimiter() {
+    return this.scopeDelimiter!=null;
   }
 }


### PR DESCRIPTION
Hello,
@pmlopes I would like to have your opinion regarding scopes & JWT.

Audience ("aud") claim aim is to ensure/validate that the JWT has been created for the RS (Resource Server):
 - The Authorization Server (Okta, Auth0, Keycloak, ...) when included into and id_token.
 - The API when used as an access_token.

The audience is great when a JWT is intended to be used by several RS, we can keep control of how it is used. _Let's say we have several APIs (A,B,C,D,E...) and the JWT is intended to be used only for the APIs A,C,E, then we do expect that API B & D will reject the JWT._

---

Scopes ("scope") claim aim is to protect a resource exposed through an API endpoint.  
_For example, the "body" scope is used to protect the user body information behind /api/health/..._

I exchanged with many security people/company, the use of audience & scopes are strongly recommended. I am using Vertx and the JWTAuth handler to protect my resources. Could you have a look to this pull request, and if not convenient, could you give me some insight to do it in a proper way?

_FYI, I am also using the Vertx Open Api Contract (OpenAPI3Router), I am expecting to deep dive into this later for the same reasons._

Thanks a lot for your help,
Regards,
Alexandre.

