### PR TITLE
Updated pom to enable impl package be exported in OSGi

### DIFF
--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -65,7 +65,7 @@
           Import-Package: \
             io.vertx.codegen.annotations;resolution:=optional,\
             *
-          -exportcontents: !*impl, !examples, *
+          -exportcontents: *impl, !examples, *
         ]]></bnd>
       </configuration>
     </plugin>


### PR DESCRIPTION
Hello,
@pmlopes  experienced issues with vertx-auth when trying to import into apache Karaf,
I have rebuilt the vertx-auth-common offline with the changes proposed below and it worked as expected hence creating this pull request.
io.vertx.ext.web.handler.BasicAuthHandler requires io.vertx.ext.auth.impl.AuthProviderInternal class from vertx-auth-common. On the Pom file this package is not exported and as such OSGi container 
 complains as below.

```
java.lang.NoClassDefFoundError: io/vertx/ext/auth/impl/AuthProviderInternal
	at io.vertx.ext.web.handler.impl.BasicAuthHandlerImpl.verifyProvider(BasicAuthHandlerImpl.java:40) ~[?:?]
	at io.vertx.ext.web.handler.impl.BasicAuthHandlerImpl.<init>(BasicAuthHandlerImpl.java:47) ~[?:?]
```
enabling package impl to be exported in vertx-auth-common makes the AuthProviderInternal class visible to vertx-web on the OSGi Container
