### PR TITLE
[Issue-317] PubSecKeyOptions is missing toJson() method

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
@@ -45,6 +45,12 @@ public class PubSecKeyOptions {
     PubSecKeyOptionsConverter.fromJson(json, this);
   }
 
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    PubSecKeyOptionsConverter.toJson(this, json);
+    return json;
+  }
+
   public String getAlgorithm() {
     return algorithm;
   }


### PR DESCRIPTION
Fixes #317 

Added `toJson()` method to `PubSecKeyOptions`.

The changes will update the following generated Converters:
* [vertx-auth-jwt/src/main/generated/io/vertx/ext/auth/jwt/JWTAuthOptionsConverter.java](https://github.com/vert-x3/vertx-auth/blob/master/vertx-auth-jwt/src/main/generated/io/vertx/ext/auth/jwt/JWTAuthOptionsConverter.java#L61)
* [vertx-auth-oauth2/src/main/generated/io/vertx/ext/auth/oauth2/OAuth2ClientOptionsConverter.java](https://github.com/vert-x3/vertx-auth/blob/master/vertx-auth-oauth2/src/main/generated/io/vertx/ext/auth/oauth2/OAuth2ClientOptionsConverter.java#L141)
