### PR TITLE
Proposal to enhance User

### DIFF
--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/JWTAuth.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/JWTAuth.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.auth.jwt;
 
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
@@ -105,7 +105,6 @@ public class JWTAuthProviderImpl implements JWTAuth {
   @Override
   public void authenticate(JsonObject authInfo, Handler<AsyncResult<User>> resultHandler) {
     try {
-      final String credentials = authInfo.getString("jwt");
       final JsonObject payload = jwt.decode(authInfo.getString("jwt"));
 
       if (jwt.isExpired(payload, jwtOptions)) {
@@ -139,7 +138,7 @@ public class JWTAuthProviderImpl implements JWTAuth {
         return;
       }
 
-      resultHandler.handle(Future.succeededFuture(new JWTUser(credentials, payload, permissionsClaimKey)));
+      resultHandler.handle(Future.succeededFuture(new JWTUser(payload, permissionsClaimKey)));
 
     } catch (RuntimeException e) {
       resultHandler.handle(Future.failedFuture(e));

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
@@ -105,6 +105,7 @@ public class JWTAuthProviderImpl implements JWTAuth {
   @Override
   public void authenticate(JsonObject authInfo, Handler<AsyncResult<User>> resultHandler) {
     try {
+      final String credentials = authInfo.getString("jwt");
       final JsonObject payload = jwt.decode(authInfo.getString("jwt"));
 
       if (jwt.isExpired(payload, jwtOptions)) {
@@ -138,7 +139,7 @@ public class JWTAuthProviderImpl implements JWTAuth {
         return;
       }
 
-      resultHandler.handle(Future.succeededFuture(new JWTUser(payload, permissionsClaimKey)));
+      resultHandler.handle(Future.succeededFuture(new JWTUser(credentials, payload, permissionsClaimKey)));
 
     } catch (RuntimeException e) {
       resultHandler.handle(Future.failedFuture(e));

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTUser.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTUser.java
@@ -35,8 +35,6 @@ public class JWTUser extends AbstractUser {
 
   private static final Logger log = LoggerFactory.getLogger(JWTUser.class);
 
-  private String credentials;
-
   private JsonObject jwtToken;
   private JsonArray permissions;
 
@@ -46,8 +44,7 @@ public class JWTUser extends AbstractUser {
     log.info("You are probably serializing the JWT User, JWT are supposed to be used in stateless servers!");
   }
 
-  public JWTUser(String credentials, JsonObject jwtToken, String permissionsClaimKey) {
-    this.credentials = credentials;
+  public JWTUser(JsonObject jwtToken, String permissionsClaimKey) {
     this.jwtToken = jwtToken;
 
     if(permissionsClaimKey.contains("/")) {
@@ -106,10 +103,6 @@ public class JWTUser extends AbstractUser {
     super.writeToBuffer(buff);
     byte[] bytes;
 
-    bytes = credentials.getBytes(StandardCharsets.UTF_8);
-    buff.appendInt(bytes.length);
-    buff.appendBytes(bytes);
-
     bytes = jwtToken.encode().getBytes(StandardCharsets.UTF_8);
     buff.appendInt(bytes.length);
     buff.appendBytes(bytes);
@@ -132,12 +125,6 @@ public class JWTUser extends AbstractUser {
     len = buffer.getInt(pos);
     pos += 4;
     bytes = buffer.getBytes(pos, pos + len);
-    credentials = new String(bytes, StandardCharsets.UTF_8);
-    pos += len;
-
-    len = buffer.getInt(pos);
-    pos += 4;
-    bytes = buffer.getBytes(pos, pos + len);
     jwtToken = new JsonObject(new String(bytes, StandardCharsets.UTF_8));
     pos += len;
 
@@ -149,10 +136,5 @@ public class JWTUser extends AbstractUser {
       pos += len;
     }
     return pos;
-  }
-
-  @Override
-  public String httpAuthorization() {
-    return "Bearer " + credentials;
   }
 }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/AccessToken.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/AccessToken.java
@@ -36,11 +36,6 @@ import io.vertx.ext.auth.User;
 public interface AccessToken extends User {
 
   /**
-   * Check if the access token is expired or not.
-   */
-  boolean expired();
-
-  /**
    * Check if the access token own the required scopes to access to the resource.
    */
   boolean isScopeGranted();


### PR DESCRIPTION
This is a proposal to enhance the User object.

* add `expired()` which shall be used by providers that issue time based tokens
* add `httpAuthorization()` which returns a HTTP Authorization header formatted for the user

The later is useful to allow the `web-client` project to just use `User` objects when creating HTTP requests. for example:

```java
User me = ... // user obtained from a JWT / OAuth2 request / etc...

client
  .get("somehost", "somepath")
  .httpAuthorization(me);
```