### PR TITLE
Add User attributes

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/User.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/User.java
@@ -37,12 +37,23 @@ import io.vertx.ext.auth.impl.UserImpl;
 public interface User {
 
   static User create(JsonObject principal) {
-    return new UserImpl(principal);
+    return create(principal, new JsonObject());
+  }
+
+  static User create(JsonObject principal, JsonObject attributes) {
+    return new UserImpl(principal, attributes);
   }
 
   /**
+   * Gets extra attributes of the user. Attributes contains any attributes related
+   * to the outcome of authenticating a user (e.g.: issued date, metadata, etc...)
+   * @return a json object with any relevant attribute.
+   */
+  JsonObject attributes();
+
+  /**
    * returns user's authorizations
-   * 
+   *
    * @return
    */
   default Authorizations authorizations() {
@@ -77,7 +88,7 @@ public interface User {
     isAuthorized(authority, promise);
     return promise.future();
   }
- 
+
   /**
    * The User object will cache any authorities that it knows it has to avoid hitting the
    * underlying auth provider each time.  Use this method if you want to clear this cache.

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/UserConverter.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/UserConverter.java
@@ -22,6 +22,7 @@ import io.vertx.ext.auth.User;
 public class UserConverter {
 
   private final static String FIELD_PRINCIPAL = "principal";
+  private final static String FIELD_ATTRIBUTES = "attributes";
   private final static String FIELD_AUTHORIZATIONS = "authorizations";
 
   public static JsonObject encode(User value) throws IllegalArgumentException {
@@ -29,6 +30,7 @@ public class UserConverter {
 
     JsonObject json = new JsonObject();
     json.put(FIELD_PRINCIPAL, value.principal());
+    json.put(FIELD_ATTRIBUTES, value.attributes());
     JsonObject jsonAuthorizations = new JsonObject();
     for (String providerId: value.authorizations().getProviderIds()) {
       JsonArray jsonAuthorizationByProvider = new JsonArray();
@@ -45,7 +47,8 @@ public class UserConverter {
     Objects.requireNonNull(json);
 
     JsonObject principal = json.getJsonObject(FIELD_PRINCIPAL);
-    User user = User.create(principal);
+    JsonObject attributes = json.getJsonObject(FIELD_ATTRIBUTES);
+    User user = User.create(principal, attributes);
     // authorizations
     JsonObject jsonAuthorizations = json.getJsonObject(FIELD_AUTHORIZATIONS);
     for (String fieldName: jsonAuthorizations.fieldNames()) {
@@ -57,5 +60,4 @@ public class UserConverter {
     }
     return user;
   }
-
 }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
@@ -57,6 +57,10 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
     super(provider, token);
   }
 
+  public JsonObject attributes() {
+    return new JsonObject();
+  }
+
   @Override
   public AccessToken setTrustJWT(boolean trust) {
     // refresh the tokens


### PR DESCRIPTION
Add the `attributes` property to the user interface as originally drafted on the proposal.

The attributes are a good idea that initially I did not grasp and were excluded on the pull request that followed the API enhancement.

This extra field can be useful for adding extra metadata to the user principal. For example:

* when was this user object created? (so we can perform time based expiration validation)
* where can we find `xyz` on the principal? (for token based authz different providers can hold the value to assert on different locations)
* ...