### PR TITLE
use the right codec

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/KeycloakHelper.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/KeycloakHelper.java
@@ -126,7 +126,7 @@ public interface KeycloakHelper {
       throw new IllegalArgumentException("Parsing error");
     }
     try {
-      String decoded = new String(Base64.getDecoder().decode(parts[1]), "UTF-8");
+      String decoded = new String(Base64.getUrlDecoder().decode(parts[1]), "UTF-8");
       return new JsonObject(decoded); // get "payload" part
     } catch (Exception e) {
       e.printStackTrace();


### PR DESCRIPTION
This is a backport of the codec fix from the master to the 3.8 branch