### PR TITLE
issue #312 - fixed SQL DDL so the tuple (role,perm) is a unique key

### DIFF
--- a/vertx-auth-jdbc/src/main/asciidoc/index.adoc
+++ b/vertx-auth-jdbc/src/main/asciidoc/index.adoc
@@ -68,10 +68,9 @@ CREATE TABLE `roles_perms` (
 
 ALTER TABLE user ADD CONSTRAINT `pk_username` PRIMARY KEY (username);
 ALTER TABLE user_roles ADD CONSTRAINT `pk_user_roles` PRIMARY KEY (username, role);
-ALTER TABLE roles_perms ADD CONSTRAINT `pk_roles_perms` PRIMARY KEY (role);
+ALTER TABLE roles_perms ADD CONSTRAINT `pk_roles_perms` PRIMARY KEY (role, perm);
 
 ALTER TABLE user_roles ADD CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES user(username);
-ALTER TABLE user_roles ADD CONSTRAINT fk_roles FOREIGN KEY (role) REFERENCES roles_perms(role);
 ----
 
 == Hashing Strategy

--- a/vertx-auth-jdbc/src/main/resources/jdbc-auth-ddl.sql
+++ b/vertx-auth-jdbc/src/main/resources/jdbc-auth-ddl.sql
@@ -16,7 +16,6 @@ CREATE TABLE `roles_perms` (
 
 ALTER TABLE user ADD CONSTRAINT `pk_username` PRIMARY KEY (username);
 ALTER TABLE user_roles ADD CONSTRAINT `pk_user_roles` PRIMARY KEY (username, role);
-ALTER TABLE roles_perms ADD CONSTRAINT `pk_roles_perms` PRIMARY KEY (role);
+ALTER TABLE roles_perms ADD CONSTRAINT `pk_roles_perms` PRIMARY KEY (role, perm);
 
 ALTER TABLE user_roles ADD CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES user(username);
-ALTER TABLE user_roles ADD CONSTRAINT fk_roles FOREIGN KEY (role) REFERENCES roles_perms(role);

--- a/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthTest.java
+++ b/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthTest.java
@@ -43,6 +43,9 @@ public class JDBCAuthTest extends VertxTestBase {
     SQL.add("create table user_roles (username varchar(255), role varchar(255));");
     SQL.add("create table roles_perms (role varchar(255), perm varchar(255));");
 
+    SQL.add("ALTER TABLE user_roles ADD CONSTRAINT pk_user_roles PRIMARY KEY (username, role);");
+    SQL.add("ALTER TABLE roles_perms ADD CONSTRAINT pk_roles_perms PRIMARY KEY (role, perm);");
+
     SQL.add("insert into user values ('tim', 'EC0D6302E35B7E792DF9DA4A5FE0DB3B90FCAB65A6215215771BF96D498A01DA8234769E1CE8269A105E9112F374FDAB2158E7DA58CDC1348A732351C38E12A0', 'C59EB438D1E24CACA2B1A48BC129348589D49303858E493FBE906A9158B7D5DC');");
     SQL.add("insert into user_roles values ('tim', 'dev');");
     SQL.add("insert into user_roles values ('tim', 'admin');");

--- a/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthenticationProviderTest.java
+++ b/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthenticationProviderTest.java
@@ -41,16 +41,9 @@ public class JDBCAuthenticationProviderTest extends VertxTestBase {
   static {
     SQL.add("drop table if exists user;");
     SQL.add("create table user (username varchar(255), password varchar(255), password_salt varchar(255) );");
-//    SQL.add("create table user_roles (username varchar(255), role varchar(255));");
-//    SQL.add("create table roles_perms (role varchar(255), perm varchar(255));");
 
     SQL.add(
       "insert into user values ('tim', 'EC0D6302E35B7E792DF9DA4A5FE0DB3B90FCAB65A6215215771BF96D498A01DA8234769E1CE8269A105E9112F374FDAB2158E7DA58CDC1348A732351C38E12A0', 'C59EB438D1E24CACA2B1A48BC129348589D49303858E493FBE906A9158B7D5DC');");
-//    SQL.add("insert into user_roles values ('tim', 'dev');");
-//    SQL.add("insert into user_roles values ('tim', 'admin');");
-//    SQL.add("insert into roles_perms values ('dev', 'commit_code');");
-//    SQL.add("insert into roles_perms values ('dev', 'eat_pizza');");
-//    SQL.add("insert into roles_perms values ('admin', 'merge_pr');");
 
     // add another user using nonces
     SQL.add(
@@ -63,19 +56,10 @@ public class JDBCAuthenticationProviderTest extends VertxTestBase {
     // and a second set of tables with slight differences
 
     SQL.add("drop table if exists user2;");
-//    SQL.add("drop table if exists user_roles2;");
-//    SQL.add("drop table if exists roles_perms2;");
     SQL.add("create table user2 (user_name varchar(255), pwd varchar(255), pwd_salt varchar(255) );");
-//    SQL.add("create table user_roles2 (user_name varchar(255), role varchar(255));");
-//    SQL.add("create table roles_perms2 (role varchar(255), perm varchar(255));");
 
     SQL.add(
       "insert into user2 values ('tim', 'EC0D6302E35B7E792DF9DA4A5FE0DB3B90FCAB65A6215215771BF96D498A01DA8234769E1CE8269A105E9112F374FDAB2158E7DA58CDC1348A732351C38E12A0', 'C59EB438D1E24CACA2B1A48BC129348589D49303858E493FBE906A9158B7D5DC');");
-//    SQL.add("insert into user_roles2 values ('tim', 'dev');");
-//    SQL.add("insert into user_roles2 values ('tim', 'admin');");
-//    SQL.add("insert into roles_perms2 values ('dev', 'commit_code');");
-//    SQL.add("insert into roles_perms2 values ('dev', 'eat_pizza');");
-//    SQL.add("insert into roles_perms2 values ('admin', 'merge_pr');");
 
     // add another user using nonces
     SQL.add(

--- a/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthorizationProviderTest.java
+++ b/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthorizationProviderTest.java
@@ -42,11 +42,14 @@ public class JDBCAuthorizationProviderTest extends JDBCAuthenticationProviderTes
     SQL.add("create table user_roles (username varchar(255), role varchar(255));");
     SQL.add("create table roles_perms (role varchar(255), perm varchar(255));");
 
-    SQL.add("insert into user_roles values ('tim', 'dev');");
-    SQL.add("insert into user_roles values ('tim', 'admin');");
+    SQL.add("ALTER TABLE user_roles ADD CONSTRAINT pk_user_roles PRIMARY KEY (username, role);");
+    SQL.add("ALTER TABLE roles_perms ADD CONSTRAINT pk_roles_perms PRIMARY KEY (role, perm);");
+
     SQL.add("insert into roles_perms values ('dev', 'commit_code');");
     SQL.add("insert into roles_perms values ('dev', 'eat_pizza');");
     SQL.add("insert into roles_perms values ('admin', 'merge_pr');");
+    SQL.add("insert into user_roles values ('tim', 'dev');");
+    SQL.add("insert into user_roles values ('tim', 'admin');");
 
     // and a second set of tables with slight differences
     SQL.add("drop table if exists user_roles2;");
@@ -54,11 +57,11 @@ public class JDBCAuthorizationProviderTest extends JDBCAuthenticationProviderTes
     SQL.add("create table user_roles2 (user_name varchar(255), role varchar(255));");
     SQL.add("create table roles_perms2 (role varchar(255), perm varchar(255));");
 
-    SQL.add("insert into user_roles2 values ('tim', 'dev');");
-    SQL.add("insert into user_roles2 values ('tim', 'admin');");
     SQL.add("insert into roles_perms2 values ('dev', 'commit_code');");
     SQL.add("insert into roles_perms2 values ('dev', 'eat_pizza');");
     SQL.add("insert into roles_perms2 values ('admin', 'merge_pr');");
+    SQL.add("insert into user_roles2 values ('tim', 'dev');");
+    SQL.add("insert into user_roles2 values ('tim', 'admin');");
   }
 
   private JDBCAuthorization authorizationProvider;

--- a/vertx-auth-sql/src/main/asciidoc/index.adoc
+++ b/vertx-auth-sql/src/main/asciidoc/index.adoc
@@ -64,10 +64,9 @@ CREATE TABLE `roles_perms` (
 
 ALTER TABLE users ADD CONSTRAINT `pk_username` PRIMARY KEY (username);
 ALTER TABLE users_roles ADD CONSTRAINT `pk_users_roles` PRIMARY KEY (username, role);
-ALTER TABLE roles_perms ADD CONSTRAINT `pk_roles_perms` PRIMARY KEY (role);
+ALTER TABLE roles_perms ADD CONSTRAINT `pk_roles_perms` PRIMARY KEY (role, perm);
 
 ALTER TABLE users_roles ADD CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES user(username);
-ALTER TABLE users_roles ADD CONSTRAINT fk_roles FOREIGN KEY (role) REFERENCES roles_perms(role);
 ----
 
 == Hashing Strategy

--- a/vertx-auth-sql/src/main/resources/sql-auth-ddl.sql
+++ b/vertx-auth-sql/src/main/resources/sql-auth-ddl.sql
@@ -15,7 +15,6 @@ CREATE TABLE `roles_perms` (
 
 ALTER TABLE users ADD CONSTRAINT `pk_username` PRIMARY KEY (username);
 ALTER TABLE users_roles ADD CONSTRAINT `pk_users_roles` PRIMARY KEY (username, role);
-ALTER TABLE roles_perms ADD CONSTRAINT `pk_roles_perms` PRIMARY KEY (role);
+ALTER TABLE roles_perms ADD CONSTRAINT `pk_roles_perms` PRIMARY KEY (role, perm);
 
 ALTER TABLE users_roles ADD CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES user(username);
-ALTER TABLE users_roles ADD CONSTRAINT fk_roles FOREIGN KEY (role) REFERENCES roles_perms(role);


### PR DESCRIPTION
Fixed DDL for the role_perms table, added primary keys in tests, small cleanup of comments

I had to remove a foreign key constraint on role as it not valid SQL to reference a non unique column and role is no longer unique due to the change I made (which might explain where the initial issue comes from!). For information, MySQL allows those kind of foreign key as an sql extension, but other RDMS do not.