### PR TITLE
Fixes broken code

### DIFF
--- a/vertx-auth-common/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-auth-common/src/main/asciidoc/dataobjects.adoc
@@ -50,8 +50,12 @@ The PEM or Secret key buffer
 +++
 |[[certificate]]`@certificate`|`Boolean`|-
 |[[id]]`@id`|`String`|-
-|[[publicKey]]`@publicKey`|`String`|-
-|[[secretKey]]`@secretKey`|`String`|-
+|[[publicKey]]`@publicKey`|`String`|+++
+
++++
+|[[secretKey]]`@secretKey`|`String`|+++
+
++++
 |[[symmetric]]`@symmetric`|`Boolean`|-
 |===
 

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthOptions.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthOptions.java
@@ -69,7 +69,7 @@ public class JDBCAuthOptions implements io.vertx.ext.auth.AuthOptions {
         client = JDBCClient.createShared(vertx, config);
       }
     } else {
-      client = JDBCClient.create(vertx, config);
+      client = JDBCClient.createNonShared(vertx, config);
     }
     JDBCAuth auth = JDBCAuth.create(vertx, client);
     if (authenticationQuery != null) {

--- a/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthTest.java
+++ b/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthTest.java
@@ -100,7 +100,7 @@ public class JDBCAuthTest extends VertxTestBase {
   }
 
   protected JDBCAuth createProvider() {
-    JDBCClient client = JDBCClient.create(vertx, config());
+    JDBCClient client = JDBCClient.createNonShared(vertx, config());
     return JDBCAuth.create(vertx, client);
   }
 

--- a/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthenticationProviderTest.java
+++ b/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/test/jdbc/JDBCAuthenticationProviderTest.java
@@ -93,7 +93,7 @@ public class JDBCAuthenticationProviderTest extends VertxTestBase {
 
   protected JDBCClient getJDBCCLient() {
     if (jdbcClient == null) {
-      jdbcClient = JDBCClient.create(vertx, config());
+      jdbcClient = JDBCClient.createNonShared(vertx, config());
     }
     return jdbcClient;
   }


### PR DESCRIPTION
JDBCClient.create  needs a DataSource rather than a JsonObject. Replaces all occurances with JDBCClient.createNonShared.

Changes were in deprecated code