### PR TITLE
Fixes #364

### DIFF
--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/authorization/impl/MicroProfileAuthorizationImpl.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/authorization/impl/MicroProfileAuthorizationImpl.java
@@ -44,7 +44,7 @@ public class MicroProfileAuthorizationImpl implements MicroProfileAuthorization 
     final JsonObject accessToken =
       rootClaim == null ?
         user.principal() :
-        user.principal().getJsonObject(rootClaim);
+        user.attributes().getJsonObject(rootClaim);
 
     if (accessToken == null) {
       handler.handle(Future.failedFuture("User doesn't contain a decoded Token"));

--- a/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
+++ b/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
@@ -219,7 +219,7 @@ public class AuthOAuth2Examples {
 
   public void example14(User user) {
     // you can get the decoded `id_token` from the Keycloak principal
-    JsonObject idToken = user.principal().getJsonObject("idToken");
+    JsonObject idToken = user.attributes().getJsonObject("idToken");
 
     // you can also retrieve some properties directly from the Keycloak principal
     // e.g. `preferred_username`

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/KeycloakAuthorizationImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/KeycloakAuthorizationImpl.java
@@ -44,7 +44,7 @@ public class KeycloakAuthorizationImpl implements KeycloakAuthorization {
     final JsonObject accessToken =
       rootClaim == null ?
         user.principal() :
-        user.principal().getJsonObject(rootClaim);
+        user.attributes().getJsonObject(rootClaim);
 
     if (accessToken == null) {
       handler.handle(Future.failedFuture("User doesn't contain a decoded Token"));

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/AccessTokenImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/AccessTokenImpl.java
@@ -43,12 +43,12 @@ public class AccessTokenImpl extends UserImpl implements AccessToken {
 
   @Override
   public JsonObject accessToken() {
-    return principal().getJsonObject("accessToken");
+    return attributes().getJsonObject("accessToken");
   }
 
   @Override
   public JsonObject idToken() {
-    return principal().getJsonObject("idToken");
+    return attributes().getJsonObject("idToken");
   }
 
   @Override

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2KeycloakIT.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2KeycloakIT.java
@@ -260,7 +260,7 @@ public class OAuth2KeycloakIT {
         // generate a access token from the user
         User token = authn.result();
 
-        should.assertNotNull(token.principal().getJsonObject("accessToken"));
+        should.assertNotNull(token.attributes().getJsonObject("accessToken"));
         test.complete();
       });
     });

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/Oauth2TokenScopeTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/Oauth2TokenScopeTest.java
@@ -4,6 +4,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.PubSecKeyOptions;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
 import io.vertx.ext.auth.oauth2.*;
 import io.vertx.ext.auth.oauth2.authorization.ScopeAuthorization;
@@ -109,7 +110,7 @@ public class Oauth2TokenScopeTest extends VertxTestBase {
       if (res.failed()) {
         fail(res.cause());
       } else {
-        AccessToken token = (AccessToken) res.result();
+        User token = res.result();
         assertFalse(token.expired());
         testComplete();
       }
@@ -140,7 +141,7 @@ public class Oauth2TokenScopeTest extends VertxTestBase {
       if (res.failed()) {
         fail(res.cause());
       } else {
-        AccessToken token = (AccessToken) res.result();
+        User token = res.result();
         assertFalse(token.expired());
 
         ScopeAuthorization.create(" ").getAuthorizations(token, call -> {
@@ -253,7 +254,7 @@ public class Oauth2TokenScopeTest extends VertxTestBase {
       if (res.failed()) {
         fail("Test should have not failed");
       } else {
-        AccessToken token = (AccessToken) res.result();
+        User token = res.result();
         assertEquals("username",token.principal().getValue("username"));
         assertNull(token.principal().getValue("scope"));
         testComplete();
@@ -281,7 +282,7 @@ public class Oauth2TokenScopeTest extends VertxTestBase {
       if (res.failed()) {
         fail("Test should have not failed");
       } else {
-        AccessToken token = (AccessToken) res.result();
+        User token = res.result();
         testComplete();
       }
     });


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

when working with tokens, "accessToken" and "idToken" are decoded from the original response object. In order to safe guard against malformed tokens, the decoded values are stored on the `User` attributes and are not read from the response object.

This guarantees that the data is not mistakenly read from bad tokens but only valid decoded tokens.