### PR TITLE
MongoUserUtil: pass the created document identifiers

### DIFF
--- a/vertx-auth-mongo/pom.xml
+++ b/vertx-auth-mongo/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <version>2.0.3</version>
+      <version>2.2.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoUserUtil.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoUserUtil.java
@@ -61,17 +61,17 @@ public interface MongoUserUtil {
    * @param password
    *          the passsword in clear text, will be adapted following the definitions of the defined strategy
    * @param resultHandler
-   *          the ResultHandler will be provided with the result of the operation
+   *          the ResultHandler will be provided with the result of the operation and the created user document identifier
    * @return fluent self
    */
   @Fluent
-  MongoUserUtil createUser(String username, String password, Handler<AsyncResult<Void>> resultHandler);
+  MongoUserUtil createUser(String username, String password, Handler<AsyncResult<String>> resultHandler);
 
   /**
    * @see #createUser(String, String, Handler).
    */
-  default Future<Void> createUser(String username, String password) {
-    Promise<Void> promise = Promise.promise();
+  default Future<String> createUser(String username, String password) {
+    Promise<String> promise = Promise.promise();
     createUser(username, password, promise);
     return promise.future();
   }
@@ -84,17 +84,17 @@ public interface MongoUserUtil {
    * @param hash
    *          the password hash, as result of {@link io.vertx.ext.auth.HashingStrategy#hash(String, Map, String, String)}
    * @param resultHandler
-   *          the ResultHandler will be provided with the result of the operation
+   *          the ResultHandler will be provided with the result of the operation and the created user document identifier
    * @return fluent self
    */
   @Fluent
-  MongoUserUtil createHashedUser(String username, String hash, Handler<AsyncResult<Void>> resultHandler);
+  MongoUserUtil createHashedUser(String username, String hash, Handler<AsyncResult<String>> resultHandler);
 
   /**
    * @see #createHashedUser(String, String, Handler).
    */
-  default Future<Void> createHashedUser(String username, String hash) {
-    Promise<Void> promise = Promise.promise();
+  default Future<String> createHashedUser(String username, String hash) {
+    Promise<String> promise = Promise.promise();
     createHashedUser(username, hash, promise);
     return promise.future();
   }
@@ -109,17 +109,17 @@ public interface MongoUserUtil {
    * @param permissions
    *          a to be set
    * @param resultHandler
-   *          the ResultHandler will be provided with the result of the operation
+   *          the ResultHandler will be provided with the result of the operation and the created user document identifier
    * @return fluent self
    */
   @Fluent
-  MongoUserUtil createUserRolesAndPermissions(String username, List<String> roles, List<String> permissions, Handler<AsyncResult<Void>> resultHandler);
+  MongoUserUtil createUserRolesAndPermissions(String username, List<String> roles, List<String> permissions, Handler<AsyncResult<String>> resultHandler);
 
   /**
    * @see #createUserRolesAndPermissions(String, List, List, Handler).
    */
-  default Future<Void> createUserRolesAndPermissions(String user, List<String> roles, List<String> permissions) {
-    Promise<Void> promise = Promise.promise();
+  default Future<String> createUserRolesAndPermissions(String user, List<String> roles, List<String> permissions) {
+    Promise<String> promise = Promise.promise();
     createUserRolesAndPermissions(user, roles, permissions, promise);
     return promise.future();
   }

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUserUtilImpl.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUserUtilImpl.java
@@ -80,7 +80,7 @@ public class MongoUserUtilImpl implements MongoUserUtil {
       authnOptions.getCollectionName(),
       new JsonObject()
         .put(authnOptions.getUsernameCredentialField(), username)
-        .put(authnOptions.getUsernameCredentialField(), hash),
+        .put(authnOptions.getPasswordCredentialField(), hash),
       resultHandler);
     return this;
   }

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUserUtilImpl.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUserUtilImpl.java
@@ -50,7 +50,7 @@ public class MongoUserUtilImpl implements MongoUserUtil {
   }
 
   @Override
-  public MongoUserUtil createUser(String username, String password, Handler<AsyncResult<Void>> resultHandler) {
+  public MongoUserUtil createUser(String username, String password, Handler<AsyncResult<String>> resultHandler) {
     if (username == null || password == null) {
       resultHandler.handle(Future.failedFuture("username or password are null"));
       return this;
@@ -70,7 +70,7 @@ public class MongoUserUtilImpl implements MongoUserUtil {
   }
 
   @Override
-  public MongoUserUtil createHashedUser(String username, String hash, Handler<AsyncResult<Void>> resultHandler) {
+  public MongoUserUtil createHashedUser(String username, String hash, Handler<AsyncResult<String>> resultHandler) {
     if (username == null || hash == null) {
       resultHandler.handle(Future.failedFuture("username or password hash are null"));
       return this;
@@ -81,18 +81,12 @@ public class MongoUserUtilImpl implements MongoUserUtil {
       new JsonObject()
         .put(authnOptions.getUsernameCredentialField(), username)
         .put(authnOptions.getUsernameCredentialField(), hash),
-      save -> {
-        if (save.succeeded()) {
-          resultHandler.handle(Future.succeededFuture());
-        } else {
-          resultHandler.handle(Future.failedFuture(save.cause()));
-        }
-      });
+      resultHandler);
     return this;
   }
 
   @Override
-  public MongoUserUtil createUserRolesAndPermissions(String username, List<String> roles, List<String> permissions, Handler<AsyncResult<Void>> resultHandler) {
+  public MongoUserUtil createUserRolesAndPermissions(String username, List<String> roles, List<String> permissions, Handler<AsyncResult<String>> resultHandler) {
     if (username == null) {
       resultHandler.handle(Future.failedFuture("username is null"));
       return this;
@@ -104,13 +98,7 @@ public class MongoUserUtilImpl implements MongoUserUtil {
         .put(authzOptions.getUsernameField(), username)
         .put(authzOptions.getRoleField(), roles == null ? Collections.emptyList() : roles)
         .put(authzOptions.getPermissionField(), permissions == null ? Collections.emptyList() : permissions),
-      save -> {
-        if (save.succeeded()) {
-          resultHandler.handle(Future.succeededFuture());
-        } else {
-          resultHandler.handle(Future.failedFuture(save.cause()));
-        }
-      });
+      resultHandler);
 
     return this;
   }

--- a/vertx-auth-mongo/src/test/java/io/vertx/ext/auth/mongo/test/MongoUserUtilTest.java
+++ b/vertx-auth-mongo/src/test/java/io/vertx/ext/auth/mongo/test/MongoUserUtilTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.auth.mongo.test;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.authorization.Authorization;
+import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
+import io.vertx.ext.auth.authorization.RoleBasedAuthorization;
+import io.vertx.ext.auth.mongo.*;
+import io.vertx.ext.mongo.MongoClient;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+public class MongoUserUtilTest extends MongoBaseTest {
+
+  @Test
+  public void createUserSmokeTest() throws Throwable {
+    MongoClient mongoClient = this.getMongoClient();
+    MongoAuthentication authProvider = MongoAuthentication.create(mongoClient, new MongoAuthenticationOptions());
+    MongoUserUtil userUtil = MongoUserUtil.create(mongoClient);
+    userUtil.createUser("foo", "bar")
+      .flatMap(id -> {
+        assertTrue(id.length() > 0);
+        JsonObject credentials = new JsonObject()
+          .put("username", "foo")
+          .put("password", "bar");
+        return authProvider.authenticate(credentials);
+      })
+      .onFailure(this::fail)
+      .onSuccess(user -> {
+        assertEquals("foo", user.principal().getString("username"));
+        this.complete();
+      });
+    await();
+  }
+
+  @Test
+  public void createUserAndPermissionsTest() throws Throwable {
+    MongoClient mongoClient = this.getMongoClient();
+    MongoAuthentication authnProvider = MongoAuthentication.create(mongoClient, new MongoAuthenticationOptions());
+    MongoAuthorization authzProvider = MongoAuthorization.create("abc", mongoClient, new MongoAuthorizationOptions());
+    MongoUserUtil userUtil = MongoUserUtil.create(mongoClient);
+    List<String> roles = Arrays.asList("a", "b");
+    List<String> perms = Arrays.asList("c", "d");
+    JsonObject credentials = new JsonObject()
+      .put("username", "fizz")
+      .put("password", "buzz");
+    userUtil
+      .createUser("fizz", "buzz")
+      .flatMap(id -> userUtil.createUserRolesAndPermissions("fizz", roles, perms))
+      .flatMap(id -> authnProvider.authenticate(credentials))
+      .flatMap(user -> authzProvider.getAuthorizations(user).map(v -> user))
+      .onFailure(this::fail)
+      .onSuccess(user -> {
+        Set<Authorization> auths = user.authorizations().get("abc");
+        assertTrue(auths.contains(RoleBasedAuthorization.create("a")));
+        assertTrue(auths.contains(RoleBasedAuthorization.create("b")));
+        assertFalse(auths.contains(RoleBasedAuthorization.create("c")));
+        assertTrue(auths.contains(PermissionBasedAuthorization.create("c")));
+        assertTrue(auths.contains(PermissionBasedAuthorization.create("d")));
+        assertFalse(auths.contains(PermissionBasedAuthorization.create("e")));
+        this.complete();
+      });
+    await();
+  }
+}

--- a/vertx-auth-sql/src/main/java/examples/AuthSqlExamples.java
+++ b/vertx-auth-sql/src/main/java/examples/AuthSqlExamples.java
@@ -86,7 +86,7 @@ public class AuthSqlExamples {
       "sausages" // password
     );
     // save to the database
-    sqlClient.preparedQuery("INSERT INTO user (username, password) VALUES (?, ?)", Tuple.of("tim", hash), ar -> {
+    sqlClient.preparedQuery("INSERT INTO user (username, password) VALUES (?, ?)").execute(Tuple.of("tim", hash), ar -> {
       if (ar.succeeded()) {
         // password updated
       }

--- a/vertx-auth-sql/src/main/java/io/vertx/ext/auth/sql/impl/SqlAuthenticationImpl.java
+++ b/vertx-auth-sql/src/main/java/io/vertx/ext/auth/sql/impl/SqlAuthenticationImpl.java
@@ -60,7 +60,7 @@ public class SqlAuthenticationImpl implements SqlAuthentication {
       return;
     }
 
-    client.preparedQuery(options.getAuthenticationQuery(), Tuple.of(username), preparedQuery -> {
+    client.preparedQuery(options.getAuthenticationQuery()).execute(Tuple.of(username), preparedQuery -> {
       if (preparedQuery.succeeded()) {
         final RowSet<Row> rows = preparedQuery.result();
         switch (rows.size()) {

--- a/vertx-auth-sql/src/main/java/io/vertx/ext/auth/sql/impl/SqlAuthorizationImpl.java
+++ b/vertx-auth-sql/src/main/java/io/vertx/ext/auth/sql/impl/SqlAuthorizationImpl.java
@@ -36,7 +36,7 @@ public class SqlAuthorizationImpl implements SqlAuthorization {
 
   private void getRoles(String username, Handler<AsyncResult<Set<Authorization>>> resultHandler) {
     if (options.getRolesQuery() != null) {
-      client.preparedQuery(options.getRolesQuery(), Tuple.of(username), preparedQuery -> {
+      client.preparedQuery(options.getRolesQuery()).execute(Tuple.of(username), preparedQuery -> {
         if (preparedQuery.succeeded()) {
           RowSet<Row> rows = preparedQuery.result();
           Set<Authorization> authorizations = new HashSet<>();
@@ -56,7 +56,7 @@ public class SqlAuthorizationImpl implements SqlAuthorization {
 
   private void getPermissions(String username, Handler<AsyncResult<Set<Authorization>>> resultHandler) {
     if (options.getPermissionsQuery() != null) {
-      client.preparedQuery(options.getPermissionsQuery(), Tuple.of(username), preparedQuery -> {
+      client.preparedQuery(options.getPermissionsQuery()).execute(Tuple.of(username), preparedQuery -> {
         if (preparedQuery.succeeded()) {
           RowSet<Row> rows = preparedQuery.result();
           Set<Authorization> authorizations = new HashSet<>();

--- a/vertx-auth-sql/src/main/java/io/vertx/ext/auth/sql/impl/SqlUserUtilImpl.java
+++ b/vertx-auth-sql/src/main/java/io/vertx/ext/auth/sql/impl/SqlUserUtilImpl.java
@@ -78,7 +78,7 @@ public class SqlUserUtilImpl implements SqlUserUtil {
       return this;
     }
 
-    client.preparedQuery(insertUser, Tuple.of(username, hash), prepare -> {
+    client.preparedQuery(insertUser).execute(Tuple.of(username, hash), prepare -> {
       if (prepare.succeeded()) {
         resultHandler.handle(Future.succeededFuture());
       } else {
@@ -95,7 +95,7 @@ public class SqlUserUtilImpl implements SqlUserUtil {
       return this;
     }
 
-    client.preparedQuery(insertUserRole, Tuple.of(username, role), prepare -> {
+    client.preparedQuery(insertUserRole).execute(Tuple.of(username, role), prepare -> {
       if (prepare.succeeded()) {
         resultHandler.handle(Future.succeededFuture());
       } else {
@@ -112,7 +112,7 @@ public class SqlUserUtilImpl implements SqlUserUtil {
       return this;
     }
 
-    client.preparedQuery(insertRolePermission, Tuple.of(role, permission), insert -> {
+    client.preparedQuery(insertRolePermission).execute(Tuple.of(role, permission), insert -> {
       if (insert.succeeded()) {
         resultHandler.handle(Future.succeededFuture());
       } else {


### PR DESCRIPTION
This brings the behavior of `MongoUserUtil` closer to the previous `insertUser` and co APIs.

This pull-request also:

- upgrades the embedded MongoDB server, and
- fixes a bug when creating users where the password ends up in the user name.