### PR TITLE
Make the validation of the access token returned with the code grant optional

### DIFF
--- a/vertx-auth-oauth2/src/main/asciidoc/dataobjects.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/dataobjects.adoc
@@ -123,6 +123,7 @@ Set custom parameters to be sent during the userInfo resource request
 |[[userInfoPath]]`@userInfoPath`|`String`|+++
 Set the provider userInfo resource path
 +++
+|[[validateCodeFlowAccessToken]]`@validateCodeFlowAccessToken`|`Boolean`|-
 |[[validateIssuer]]`@validateIssuer`|`Boolean`|-
 |[[verifyHost]]`@verifyHost`|`Boolean`|-
 |[[webSocketCompressionAllowClientNoContext]]`@webSocketCompressionAllowClientNoContext`|`Boolean`|-
@@ -198,6 +199,7 @@ Set custom parameters to be sent during the userInfo resource request
 |[[userInfoPath]]`@userInfoPath`|`String`|+++
 Set the provider userInfo resource path
 +++
+|[[validateCodeFlowAccessToken]]`@validateCodeFlowAccessToken`|`Boolean`|-
 |[[validateIssuer]]`@validateIssuer`|`Boolean`|-
 |===
 

--- a/vertx-auth-oauth2/src/main/generated/io/vertx/ext/auth/oauth2/OAuth2ClientOptionsConverter.java
+++ b/vertx-auth-oauth2/src/main/generated/io/vertx/ext/auth/oauth2/OAuth2ClientOptionsConverter.java
@@ -125,6 +125,11 @@ public class OAuth2ClientOptionsConverter {
             obj.setUserInfoPath((String)member.getValue());
           }
           break;
+        case "validateCodeFlowAccessToken":
+          if (member.getValue() instanceof Boolean) {
+            obj.setValidateCodeFlowAccessToken((Boolean)member.getValue());
+          }
+          break;
         case "validateIssuer":
           if (member.getValue() instanceof Boolean) {
             obj.setValidateIssuer((Boolean)member.getValue());
@@ -202,6 +207,7 @@ public class OAuth2ClientOptionsConverter {
     if (obj.getUserInfoPath() != null) {
       json.put("userInfoPath", obj.getUserInfoPath());
     }
+    json.put("validateCodeFlowAccessToken", obj.isValidateCodeFlowAccessToken());
     json.put("validateIssuer", obj.isValidateIssuer());
   }
 }

--- a/vertx-auth-oauth2/src/main/generated/io/vertx/ext/auth/oauth2/OAuth2OptionsConverter.java
+++ b/vertx-auth-oauth2/src/main/generated/io/vertx/ext/auth/oauth2/OAuth2OptionsConverter.java
@@ -130,6 +130,11 @@ public class OAuth2OptionsConverter {
             obj.setUserInfoPath((String)member.getValue());
           }
           break;
+        case "validateCodeFlowAccessToken":
+          if (member.getValue() instanceof Boolean) {
+            obj.setValidateCodeFlowAccessToken((Boolean)member.getValue());
+          }
+          break;
         case "validateIssuer":
           if (member.getValue() instanceof Boolean) {
             obj.setValidateIssuer((Boolean)member.getValue());
@@ -210,6 +215,7 @@ public class OAuth2OptionsConverter {
     if (obj.getUserInfoPath() != null) {
       json.put("userInfoPath", obj.getUserInfoPath());
     }
+    json.put("validateCodeFlowAccessToken", obj.isValidateCodeFlowAccessToken());
     json.put("validateIssuer", obj.isValidateIssuer());
   }
 }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2ClientOptions.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2ClientOptions.java
@@ -47,6 +47,7 @@ public class OAuth2ClientOptions extends HttpClientOptions {
   private static final JWTOptions JWT_OPTIONS = new JWTOptions();
   private static final String SCOPE_SEPARATOR = " ";
   private static final boolean VALIDATE_ISSUER = true;
+  private static final boolean VALIDATE_CODE_FLOW_ACCESS_TOKEN = true;
 
   private OAuth2FlowType flow;
   private String authorizationPath;
@@ -55,6 +56,7 @@ public class OAuth2ClientOptions extends HttpClientOptions {
   private String scopeSeparator;
   // this is an openid-connect extension
   private boolean validateIssuer;
+  private boolean validateCodeFlowAccessToken;
   private String logoutPath;
   private boolean useBasicAuthorizationHeader;
   private String clientSecretParameterName;
@@ -112,6 +114,7 @@ public class OAuth2ClientOptions extends HttpClientOptions {
     clientSecret = other.getClientSecret();
     // defaults
     validateIssuer = other.isValidateIssuer();
+    validateCodeFlowAccessToken = other.isValidateCodeFlowAccessToken();
     flow = other.getFlow();
     authorizationPath = other.getAuthorizationPath();
     tokenPath = other.getTokenPath();
@@ -158,6 +161,7 @@ public class OAuth2ClientOptions extends HttpClientOptions {
   private void init() {
     flow = FLOW;
     validateIssuer = VALIDATE_ISSUER;
+    validateCodeFlowAccessToken = VALIDATE_CODE_FLOW_ACCESS_TOKEN;
     authorizationPath = AUTHORIZATION_PATH;
     tokenPath = TOKEN_PATH;
     revocationPath = REVOKATION_PATH;
@@ -517,6 +521,15 @@ public class OAuth2ClientOptions extends HttpClientOptions {
 
   public OAuth2ClientOptions setValidateIssuer(boolean validateIssuer) {
     this.validateIssuer = validateIssuer;
+    return this;
+  }
+
+  public boolean isValidateCodeFlowAccessToken() {
+    return validateCodeFlowAccessToken;
+  }
+
+  public OAuth2ClientOptions setValidateCodeFlowAccessToken(boolean validateCodeFlowAccessToken) {
+    this.validateCodeFlowAccessToken = validateCodeFlowAccessToken;
     return this;
   }
 

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
@@ -47,6 +47,7 @@ public class OAuth2Options {
   private static final JWTOptions JWT_OPTIONS = new JWTOptions();
   private static final String SCOPE_SEPARATOR = " ";
   private static final boolean VALIDATE_ISSUER = true;
+  private static final boolean VALIDATE_CODE_FLOW_ACCESS_TOKEN = true;
 
   private OAuth2FlowType flow;
   private String authorizationPath;
@@ -55,6 +56,7 @@ public class OAuth2Options {
   private String scopeSeparator;
   // this is an openid-connect extension
   private boolean validateIssuer;
+  private boolean validateCodeFlowAccessToken;
   private String logoutPath;
   private boolean useBasicAuthorizationHeader;
   private String clientSecretParameterName;
@@ -102,6 +104,7 @@ public class OAuth2Options {
     clientSecret = other.getClientSecret();
     // defaults
     validateIssuer = other.isValidateIssuer();
+    validateCodeFlowAccessToken = other.isValidateCodeFlowAccessToken();
     flow = other.getFlow();
     authorizationPath = other.getAuthorizationPath();
     tokenPath = other.getTokenPath();
@@ -149,6 +152,7 @@ public class OAuth2Options {
   private void init() {
     flow = FLOW;
     validateIssuer = VALIDATE_ISSUER;
+    validateCodeFlowAccessToken = VALIDATE_CODE_FLOW_ACCESS_TOKEN;
     authorizationPath = AUTHORIZATION_PATH;
     tokenPath = TOKEN_PATH;
     revocationPath = REVOKATION_PATH;
@@ -501,6 +505,15 @@ public class OAuth2Options {
 
   public OAuth2Options setValidateIssuer(boolean validateIssuer) {
     this.validateIssuer = validateIssuer;
+    return this;
+  }
+
+  public boolean isValidateCodeFlowAccessToken() {
+	    return validateCodeFlowAccessToken;
+	  }
+
+  public OAuth2Options setValidateCodeFlowAccessToken(boolean validateCodeFlowAccessToken) {
+    this.validateCodeFlowAccessToken = validateCodeFlowAccessToken;
     return this;
   }
 


### PR DESCRIPTION
Motivation:

As shown in https://github.com/quarkusio/quarkus/issues/8396, OIDC providers may return the opaque access tokens as part of the code flow - such tokens do not have to be decoded as JWT and also introspected as opaque tokens - they are only for the client web applications to propagate such a token to the remote endpoint.

It will resolve #381 once 3.9.x is updated.

@pmlopes Hi Paulo, The master code is different from the 3.9.x branch so I'll need to follow up with another PR for 3.9.x, correct once this PR is ready ? Thanks

CC @cescoffier 