### PR TITLE
Issues/oidc sec10 1 1 sec10.2.1

### DIFF
--- a/vertx-auth-oauth2/src/main/asciidoc/index.adoc
+++ b/vertx-auth-oauth2/src/main/asciidoc/index.adoc
@@ -387,3 +387,31 @@ user this is as simple as:
 ----
 {@link examples.AuthOAuth2Examples#example20}
 ----
+
+== Key Management
+
+When the provider is configured with a `jwks` path. Either manually or using the discovery mechanism, there are events
+when keys must be rotated. For this reason this provider implements the 2 recommended ways by the openid connect core
+spec.
+
+When calling the refresh method, if the server returns the recommended cache header as described on
+https://openid.net/specs/openid-connect-core-1_0.html#RotateEncKeys then a periodic task will run at the recommeneded
+time by the server to reload the keys.
+
+[source,$lang]
+----
+{@link examples.AuthOAuth2Examples#example21}
+----
+
+However there are times when servers change keys and this provider isn't aware. For example, to mitigate a leak or an
+expired certificate. In such event the server will start emitting tokens with a different kid than the ones on the store
+as described: https://openid.net/specs/openid-connect-core-1_0.html#RotateSigKeys For this situation and to avoid DDoS
+attacks the provider will notify you that a unknown key is missing:
+
+[source,$lang]
+----
+{@link examples.AuthOAuth2Examples#example22}
+----
+
+A special note on this is that if a user will send many requests with a missing key, your handler should throttle the
+calls to refresh the new key set, or you might end up DDoS your IdP server.

--- a/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
+++ b/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
@@ -426,4 +426,29 @@ public class AuthOAuth2Examples {
         }
       });
   }
+
+  public void example21(OAuth2Auth oauth2) {
+    // OAuth2Auth level
+    oauth2.jWKSet(res -> {
+      if (res.succeeded()) {
+        // load was successful, if the server returned the header
+        // `Cache-Control` with a `max-age` then a periodic task
+        // will run at that time to refresh the keys
+      }
+    });
+  }
+
+  public void example22(OAuth2Auth oauth2) {
+    // OAuth2Auth level
+    oauth2.missingKeyHandler(keyId -> {
+      // we can now decide what to do:
+      // 1. we can inspect the key id, does it make sense?
+      if (keyId.equals("the-new-id")) {
+        // 2. refresh the keys
+        oauth2.jWKSet(res -> {
+          // ...
+        });
+      }
+    });
+  }
 }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/KeycloakAuthorizationImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/KeycloakAuthorizationImpl.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 public class KeycloakAuthorizationImpl implements KeycloakAuthorization {
 
-  private static final JsonObject EMPTY_JSON = new JsonObject(Collections.EMPTY_MAP);
+  private static final JsonObject EMPTY_JSON = new JsonObject(Collections.emptyMap());
 
   @Override
   public String getId() {

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -93,7 +93,9 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
         this.jwt = jwt;
         // compute the next update if the server told us too
         if (json.containsKey("maxAge")) {
-          this.updateTimerId = vertx.setPeriodic(json.getLong("maxAge"), t ->
+          // delay is in ms, while cache max age is sec
+          final long delay = json.getLong("maxAge") * 1000;
+          this.updateTimerId = vertx.setPeriodic(delay, t ->
             jWKSet(autoUpdateRes -> {
               if (autoUpdateRes.failed()) {
                 LOG.warn("Failed to auto-update JWK Set", autoUpdateRes.cause());

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -18,6 +18,7 @@ package io.vertx.ext.auth.oauth2.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.Json;
@@ -30,6 +31,7 @@ import io.vertx.ext.auth.oauth2.*;
 import io.vertx.ext.jwt.JWK;
 import io.vertx.ext.jwt.JWT;
 import io.vertx.ext.jwt.JWTOptions;
+import io.vertx.ext.jwt.NoSuchKeyIdException;
 
 import java.util.Collections;
 
@@ -40,14 +42,18 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
 
   private static final Logger LOG = LoggerFactory.getLogger(OAuth2AuthProviderImpl.class);
 
+  private final Vertx vertx;
   private final OAuth2Options config;
   private final OAuth2API api;
 
   private JWT jwt = new JWT();
+  private long updateTimerId = -1;
+  private Handler<String> missingKeyHandler;
 
-  public OAuth2AuthProviderImpl(OAuth2API api, OAuth2Options config) {
-    this.api = api;
+  public OAuth2AuthProviderImpl(Vertx vertx, OAuth2Options config) {
+    this.vertx = vertx;
     this.config = config;
+    this.api = new OAuth2API(vertx, config);
     // compute paths with variables, at this moment it is only relevant that
     // all variables are properly computed
     this.config.replaceVariables(true);
@@ -62,12 +68,21 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
 
   @Override
   public OAuth2Auth jWKSet(Handler<AsyncResult<Void>> handler) {
+    // cancel any running timer to avoid multiple updates
+    // it is not important if the timer isn't active anymore
+
+    // this could happen if both the user triggers the update and
+    // there's a timer already in progress
+    vertx.cancelTimer(updateTimerId);
+
     api.jwkSet(res -> {
       if (res.failed()) {
         handler.handle(Future.failedFuture(res.cause()));
       } else {
+        final JsonObject json = res.result();
         JWT jwt = new JWT();
-        for (Object key : res.result()) {
+        JsonArray keys = json.getJsonArray("keys");
+        for (Object key : keys) {
           try {
             jwt.addJWK(new JWK((JsonObject) key));
           } catch (RuntimeException e) {
@@ -76,10 +91,25 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
         }
         // swap
         this.jwt = jwt;
+        // compute the next update if the server told us too
+        if (json.containsKey("maxAge")) {
+          this.updateTimerId = vertx.setPeriodic(json.getLong("maxAge"), t ->
+            jWKSet(autoUpdateRes -> {
+              if (autoUpdateRes.failed()) {
+                LOG.warn("Failed to auto-update JWK Set", autoUpdateRes.cause());
+              }
+            }));
+        }
         // return
         handler.handle(Future.succeededFuture());
       }
     });
+    return this;
+  }
+
+  @Override
+  public OAuth2Auth missingKeyHandler(Handler<String> handler) {
+    this.missingKeyHandler = handler;
     return this;
   }
 
@@ -324,6 +354,15 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
           user.attributes()
             .put("rootClaim", "accessToken");
 
+        } catch (NoSuchKeyIdException e) {
+          // the JWT store has no knowledge about the key id on this token
+          // if the user has specified a handler for this situation then it
+          // shall be executed, otherwise just log as a typical validation
+          if (missingKeyHandler != null) {
+            missingKeyHandler.handle(e.id());
+          } else {
+            LOG.trace("Cannot decode access token:", e);
+          }
         } catch (DecodeException | IllegalStateException e) {
           // explicitly catch and log. The exception here is a valid case
           // the reason is that it can be for several factors, such as bad token
@@ -337,6 +376,26 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
         try {
           user.attributes()
             .put("idToken", jwt.decode(json.getString("id_token")));
+
+          // re-compute expires at if not present and id token has been successfully decoded from JWT
+          if (!user.attributes().containsKey("exp")) {
+            Long exp = user.attributes()
+              .getJsonObject("idToken").getLong("exp");
+
+            if (exp != null) {
+              user.attributes()
+                .put("exp", exp);
+            }
+          }
+        } catch (NoSuchKeyIdException e) {
+          // the JWT store has no knowledge about the key id on this token
+          // if the user has specified a handler for this situation then it
+          // shall be executed, otherwise just log as a typical validation
+          if (missingKeyHandler != null) {
+            missingKeyHandler.handle(e.id());
+          } else {
+            LOG.trace("Cannot decode access token:", e);
+          }
         } catch (DecodeException | IllegalStateException e) {
           // explicity catch and log. The exception here is a valid case
           // the reason is that it can be for several factors, such as bad token
@@ -471,6 +530,15 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
         user.attributes()
           .put("rootClaim", "accessToken");
 
+      } catch (NoSuchKeyIdException e) {
+        // the JWT store has no knowledge about the key id on this token
+        // if the user has specified a handler for this situation then it
+        // shall be executed, otherwise just log as a typical validation
+        if (missingKeyHandler != null) {
+          missingKeyHandler.handle(e.id());
+        } else {
+          LOG.trace("Cannot decode access token:", e);
+        }
       } catch (DecodeException | IllegalStateException e) {
         // explicity catch and log as trace. exception here is a valid case
         // the reason is that it can be for several factors, such as bad token
@@ -484,6 +552,15 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
       try {
         user.attributes()
           .put("idToken", jwt.decode(json.getString("id_token")));
+      } catch (NoSuchKeyIdException e) {
+        // the JWT store has no knowledge about the key id on this token
+        // if the user has specified a handler for this situation then it
+        // shall be executed, otherwise just log as a typical validation
+        if (missingKeyHandler != null) {
+          missingKeyHandler.handle(e.id());
+        } else {
+          LOG.trace("Cannot decode access token:", e);
+        }
       } catch (DecodeException | IllegalStateException e) {
         // explicity catch and log as trace. exception here is a valid case
         // the reason is that it can be for several factors, such as bad token

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2KeyRotationTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2KeyRotationTest.java
@@ -1,16 +1,102 @@
 package io.vertx.ext.auth.test.oauth2;
 
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.oauth2.OAuth2FlowType;
+import io.vertx.ext.auth.oauth2.OAuth2Options;
 import io.vertx.ext.auth.oauth2.providers.GoogleAuth;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.vertx.ext.auth.oauth2.impl.OAuth2API.queryToJSON;
+
 public class OAuth2KeyRotationTest extends VertxTestBase {
 
+  private static final JsonObject fixtureJwks = new JsonObject(
+    "{\"keys\":" +
+      "  [    " +
+      "   {" +
+      "    \"kty\":\"RSA\"," +
+      "    \"n\": \"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw\"," +
+      "    \"e\":\"AQAB\"," +
+      "    \"alg\":\"RS256\"," +
+      "    \"kid\":\"1\"" +
+      "   }" +
+      "  ]" +
+      "}");
+
+  protected OAuth2Auth oauth2;
+  private HttpServer server;
+  private int connectionCounter;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
+    oauth2 = OAuth2Auth.create(vertx, new OAuth2Options()
+      .setFlow(OAuth2FlowType.AUTH_CODE)
+      .setClientID("client-id")
+      .setClientSecret("client-secret")
+      .setJwkPath("/oauth/jwks")
+      .setSite("http://localhost:8080"));
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicInteger cnt = new AtomicInteger(0);
+    final AtomicLong then = new AtomicLong();
+
+    server = vertx.createHttpServer()
+      .connectionHandler(c -> connectionCounter++)
+      .requestHandler(req -> {
+        if (req.method() == HttpMethod.GET && "/oauth/jwks".equals(req.path())) {
+          req.bodyHandler(buffer -> {
+            if (cnt.compareAndSet(0, 1)) {
+              then.set(System.currentTimeMillis());
+              req.response()
+                .putHeader("Content-Type", "application/json")
+                // we expect a refresh within 5 sec
+                .putHeader("Cache-Control", "public, max-age=5, must-revalidate, no-transform")
+                .end(fixtureJwks.encode());
+              return;
+            }
+            if (cnt.compareAndSet(1, 2)) {
+              if (then.get() + 5000 <= System.currentTimeMillis()) {
+                req.response()
+                  .putHeader("Content-Type", "application/json")
+                  .end(fixtureJwks.encode());
+                // allow the process to complete
+                vertx.runOnContext(v -> testComplete());
+              } else {
+                fail("wrong timing: " + (System.currentTimeMillis() - then.get()));
+              }
+            }
+          });
+        } else {
+          req.response().setStatusCode(400).end();
+        }
+      })
+      .listen(8080, ready -> {
+        if (ready.failed()) {
+          throw new RuntimeException(ready.cause());
+        }
+        // ready
+        latch.countDown();
+      });
+
+    connectionCounter = 0;
+    latch.await();
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    server.close();
+    super.tearDown();
   }
 
   @Test
@@ -20,6 +106,16 @@ public class OAuth2KeyRotationTest extends VertxTestBase {
     oauth2.jWKSet(load -> {
       assertFalse(load.failed());
       testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testAutoRefresh() {
+    oauth2.jWKSet(res -> {
+      if (res.failed()) {
+        fail(res.cause().getMessage());
+      }
     });
     await();
   }

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OpenIDCDiscoveryTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OpenIDCDiscoveryTest.java
@@ -60,7 +60,7 @@ public class OpenIDCDiscoveryTest extends VertxTestBase {
       load -> {
         // will fail as there is no application config, but the parsing should have happened
         assertTrue(load.failed());
-        assertEquals("Configuration missing. You need to specify [clientId]", load.cause().getMessage());
+        assertEquals("Not Found: {\"status\":404,\"error_description\":\"Invalid TENANT ID\",\"error_code\":\"INVALID_TENANTID\"}", load.cause().getMessage());
         testComplete();
       });
     await();

--- a/vertx-jwt/src/main/java/io/vertx/ext/jwt/Crypto.java
+++ b/vertx-jwt/src/main/java/io/vertx/ext/jwt/Crypto.java
@@ -38,7 +38,18 @@ public interface Crypto {
     "SHA512withECDSA"
   };
 
-  String getId();
+  /**
+   * The key id or null.
+   */
+  default String getId() {
+    return null;
+  }
+
+  /**
+   * A not null label for the key, labels are the same for same algorithm, kid objects
+   * but not necessarily different internal keys/certificates
+   */
+  String getLabel();
 
   byte[] sign(byte[] payload);
 
@@ -75,7 +86,7 @@ public interface Crypto {
  */
 class CryptoMac implements Crypto {
 
-  private final String id = UUID.randomUUID().toString();
+  private final String label = UUID.randomUUID().toString();
   private final Mac mac;
 
   CryptoMac(final Mac mac) {
@@ -83,8 +94,8 @@ class CryptoMac implements Crypto {
   }
 
   @Override
-  public String getId() {
-    return id;
+  public String getLabel() {
+    return label;
   }
 
   @Override
@@ -105,7 +116,7 @@ class CryptoMac implements Crypto {
  */
 class CryptoKeyPair implements Crypto {
 
-  private final String id = UUID.randomUUID().toString();
+  private final String label = UUID.randomUUID().toString();
 
   private final Signature sig;
   private final PublicKey publicKey;
@@ -132,8 +143,8 @@ class CryptoKeyPair implements Crypto {
   }
 
   @Override
-  public String getId() {
-    return id;
+  public String getLabel() {
+    return label;
   }
 
   @Override
@@ -227,7 +238,7 @@ final class CryptoNone implements Crypto {
   private static final byte[] NOOP = new byte[0];
 
   @Override
-  public String getId() {
+  public String getLabel() {
     return "none";
   }
 

--- a/vertx-jwt/src/main/java/io/vertx/ext/jwt/NoSuchKeyIdException.java
+++ b/vertx-jwt/src/main/java/io/vertx/ext/jwt/NoSuchKeyIdException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.jwt;
+
+/**
+ * No such KeyId exception is thrown when a JWT with a well known "kid" does not find a matching "kid" in the crypto
+ * list.
+ */
+public final class NoSuchKeyIdException extends RuntimeException {
+
+  private final String id;
+
+  public NoSuchKeyIdException(String alg) {
+    this(alg, "<null>");
+  }
+
+  public NoSuchKeyIdException(String alg, String kid) {
+    super("algorithm [" + alg + "]: " + kid);
+    this.id = alg + "#" + kid;
+  }
+
+  /**
+   * Returns the missing key with the format {@code ALGORITHM + '#' + KEY_ID}.
+   * @return the id of the missing key
+   */
+  public String id() {
+    return id;
+  }
+}


### PR DESCRIPTION
Motivation:

OIDC/OAuth2 servers can expose a jwk set endpoint where keys used to validate keys are published. Currently the rotation of these keys is not considered and it is up to the user to perform this task.

However after discussion with the community the OIDC spec defines how clients should handle this, and this PR implements/test it.

Community discussion: https://groups.google.com/forum/#!topic/vertx/1O3SDsQXgQ8
OIDC Core spec: https://openid.net/specs/openid-connect-core-1_0.html#RotateEncKeys