### PR TITLE
backport of master jwk reload

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Auth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Auth.java
@@ -220,4 +220,18 @@ public interface OAuth2Auth extends AuthProvider {
   @Fluent
   @Deprecated
   OAuth2Auth rbacHandler(OAuth2RBAC rbac);
-}
+
+  /**
+   * Handled to be called when a key (mentioned on a JWT) is missing from the current config.
+   * Users are advised to call {@link OAuth2Auth#loadJWK(Handler)} but being careful to implement
+   * some rate limiting function.
+   *
+   * This method isn't generic for several reasons. The provider is not aware of the capabilities
+   * of the backend IdP in terms of max allowed API calls. Some validation could be done at the
+   * key id, which only the end user is aware of.
+   * @return Future result.
+   * @see OAuth2Auth#missingKeyHandler(Handler)
+   */
+  @Fluent
+  OAuth2Auth missingKeyHandler(Handler<String> handler);
+  }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
@@ -51,7 +51,7 @@ public class OAuth2API {
     }
 
     final String url = path.charAt(0) == '/' ? config.getSite() + path : path;
-    LOG.debug("Fetching URL: " + url);
+    LOG.trace("Fetching URL: " + url);
 
     // create a request
     final HttpClientRequest request = makeRequest(vertx, config, method, url, callback);

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2ResponseImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2ResponseImpl.java
@@ -17,7 +17,7 @@ public class OAuth2ResponseImpl implements OAuth2Response {
 
 
   public OAuth2ResponseImpl(int statusCode, MultiMap headers, Buffer body) {
-    LOG.debug("New response: statusCode: "+ statusCode );
+    LOG.trace("New response: statusCode: "+ statusCode );
     this.headers = headers;
     this.body = body;
     this.statusCode = statusCode;

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2TokenImpl.java
@@ -78,7 +78,7 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
   @Override
   public OAuth2TokenImpl refresh(Handler<AsyncResult<Void>> handler) {
 
-    LOG.debug("Refreshing AccessToken");
+    LOG.trace("Refreshing AccessToken");
 
     final JsonObject headers = new JsonObject();
     final OAuth2AuthProviderImpl provider = getProvider();
@@ -165,7 +165,7 @@ public class OAuth2TokenImpl extends OAuth2UserImpl {
             handler.handle(Future.failedFuture(description));
           } else {
             OAuth2API.processNonStandardHeaders(json, reply, config.getScopeSeparator());
-            LOG.debug("Got new AccessToken");
+            LOG.trace("Got new AccessToken");
             init(json);
             handler.handle(Future.succeededFuture());
           }

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2KeyRotationTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2KeyRotationTest.java
@@ -1,16 +1,97 @@
 package io.vertx.ext.auth.test.oauth2;
 
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.oauth2.OAuth2FlowType;
+import io.vertx.ext.auth.oauth2.OAuth2ClientOptions;
 import io.vertx.ext.auth.oauth2.providers.GoogleAuth;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 public class OAuth2KeyRotationTest extends VertxTestBase {
 
+  private static final JsonObject fixtureJwks = new JsonObject(
+    "{\"keys\":" +
+      "  [    " +
+      "   {" +
+      "    \"kty\":\"RSA\"," +
+      "    \"n\": \"0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw\"," +
+      "    \"e\":\"AQAB\"," +
+      "    \"alg\":\"RS256\"," +
+      "    \"kid\":\"1\"" +
+      "   }" +
+      "  ]" +
+      "}");
+
+  protected OAuth2Auth oauth2;
+  private HttpServer server;
+  private int connectionCounter;
+
+  final AtomicInteger cnt = new AtomicInteger(0);
+  final AtomicLong then = new AtomicLong();
+
+  private Handler<HttpServerRequest> requestHandler;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
+    oauth2 = OAuth2Auth.create(vertx, new OAuth2ClientOptions()
+      .setFlow(OAuth2FlowType.AUTH_CODE)
+      .setClientID("client-id")
+      .setClientSecret("client-secret")
+      .setJwkPath("/oauth/jwks")
+      .setSite("http://localhost:8080"));
+
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    server = vertx.createHttpServer()
+      .connectionHandler(c -> connectionCounter++)
+      .requestHandler(req -> {
+        if (req.method() == HttpMethod.GET && "/oauth/jwks".equals(req.path())) {
+          req.bodyHandler(buffer -> {
+            if (cnt.compareAndSet(0, 1)) {
+              then.set(System.currentTimeMillis());
+              req.response()
+                .putHeader("Content-Type", "application/json")
+                // we expect a refresh within 5 sec
+                .putHeader("Cache-Control", "public, max-age=5, must-revalidate, no-transform")
+                .end(fixtureJwks.encode());
+              return;
+            }
+            if (cnt.compareAndSet(1, 2)) {
+              requestHandler.handle(req);
+            } else {
+              fail("Too many calls on the mock");
+            }
+          });
+        } else {
+          req.response().setStatusCode(400).end();
+        }
+      })
+      .listen(8080, ready -> {
+        if (ready.failed()) {
+          throw new RuntimeException(ready.cause());
+        }
+        // ready
+        latch.countDown();
+      });
+
+    connectionCounter = 0;
+    latch.await();
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    server.close();
+    super.tearDown();
   }
 
   @Test
@@ -20,6 +101,60 @@ public class OAuth2KeyRotationTest extends VertxTestBase {
     oauth2.loadJWK(load -> {
       assertFalse(load.failed());
       testComplete();
+    });
+    await();
+  }
+
+  @Test
+  public void testAutoRefresh() {
+    requestHandler = req -> {
+      if (then.get() + 5000 <= System.currentTimeMillis()) {
+        req.response()
+          .putHeader("Content-Type", "application/json")
+          .end(fixtureJwks.encode());
+        // allow the process to complete
+        vertx.runOnContext(n -> testComplete());
+      } else {
+        fail("wrong timing: " + (System.currentTimeMillis() - then.get()));
+      }
+    };
+
+    oauth2.loadJWK(res -> {
+      if (res.failed()) {
+        fail(res.cause().getMessage());
+      }
+    });
+    await();
+  }
+
+  @Test
+  public void testMissingKey() {
+    requestHandler = req -> {
+      fail("Unexpected, missing key was not called");
+    };
+
+    String jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjIifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.NYY8FXsouaKSuMafoNshtQ997X4x1Jta0GEtl3BAJGY";
+
+    oauth2.loadJWK(res -> {
+      if (res.failed()) {
+        fail(res.cause());
+      } else {
+        oauth2
+          .missingKeyHandler(kid -> {
+            if ("HS256#<null>".equals(kid)) {
+              testComplete();
+            } else {
+              fail("wrong key id");
+            }
+          })
+          .authenticate(new JsonObject().put("access_token", jwt), authenticate -> {
+            if (authenticate.failed()) {
+              // OK
+            } else {
+              fail("we don't have such key");
+            }
+          });
+      }
     });
     await();
   }

--- a/vertx-jwt/src/main/java/io/vertx/ext/jwt/Crypto.java
+++ b/vertx-jwt/src/main/java/io/vertx/ext/jwt/Crypto.java
@@ -38,7 +38,18 @@ public interface Crypto {
     "SHA512withECDSA"
   };
 
-  String getId();
+  /**
+   * The key id or null.
+   */
+  default String getId() {
+    return null;
+  }
+
+  /**
+   * A not null label for the key, labels are the same for same algorithm, kid objects
+   * but not necessarily different internal keys/certificates
+   */
+  String getLabel();
 
   byte[] sign(byte[] payload);
 
@@ -83,7 +94,7 @@ class CryptoMac implements Crypto {
   }
 
   @Override
-  public String getId() {
+  public String getLabel() {
     return id;
   }
 
@@ -132,7 +143,7 @@ class CryptoKeyPair implements Crypto {
   }
 
   @Override
-  public String getId() {
+  public String getLabel() {
     return id;
   }
 
@@ -227,7 +238,7 @@ final class CryptoNone implements Crypto {
   private static final byte[] NOOP = new byte[0];
 
   @Override
-  public String getId() {
+  public String getLabel() {
     return "none";
   }
 

--- a/vertx-jwt/src/main/java/io/vertx/ext/jwt/JWT.java
+++ b/vertx-jwt/src/main/java/io/vertx/ext/jwt/JWT.java
@@ -124,7 +124,7 @@ public final class JWT {
     boolean replaced = false;
 
     for (int i = 0; i < current.size(); i++) {
-      if (current.get(i).getId().equals(jwk.getId())) {
+      if (current.get(i).getLabel().equals(jwk.getLabel())) {
         // replace
         current.set(i, jwk);
         replaced = true;
@@ -277,7 +277,7 @@ public final class JWT {
     List<Crypto> cryptos = cryptoMap.get(alg);
 
     if (cryptos == null || cryptos.size() == 0) {
-      throw new RuntimeException("Algorithm not supported");
+      throw new NoSuchKeyIdException(alg);
     }
 
     // if we only allow secure alg, then none is not a valid option
@@ -290,13 +290,26 @@ public final class JWT {
       byte[] payloadInput = base64urlDecode(signatureSeg);
       byte[] signingInput = (headerSeg + "." + payloadSeg).getBytes(UTF8);
 
+      String kid = header.getString("kid");
+      boolean hasKey = false;
+
       for (Crypto c : cryptos) {
+        // if a token has a kid and it doesn't match the crypto id skip it
+        if (kid != null && c.getId() != null && !kid.equals(c.getId())) {
+          continue;
+        }
+        // signal that this object crypto's list has the required key
+        hasKey = true;
         if (c.verify(payloadInput, signingInput)) {
           return payload;
         }
       }
 
-      throw new RuntimeException("Signature verification failed");
+      if (hasKey) {
+        throw new RuntimeException("Signature verification failed");
+      } else {
+        throw new NoSuchKeyIdException(alg, kid);
+      }
     }
 
     return payload;

--- a/vertx-jwt/src/main/java/io/vertx/ext/jwt/NoSuchKeyIdException.java
+++ b/vertx-jwt/src/main/java/io/vertx/ext/jwt/NoSuchKeyIdException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.jwt;
+
+/**
+ * No such KeyId exception is thrown when a JWT with a well known "kid" does not find a matching "kid" in the crypto
+ * list.
+ */
+public final class NoSuchKeyIdException extends RuntimeException {
+
+  private final String id;
+
+  public NoSuchKeyIdException(String alg) {
+    this(alg, "<null>");
+  }
+
+  public NoSuchKeyIdException(String alg, String kid) {
+    super("algorithm [" + alg + "]: " + kid);
+    this.id = alg + "#" + kid;
+  }
+
+  /**
+   * Returns the missing key with the format {@code ALGORITHM + '#' + KEY_ID}.
+   * @return the id of the missing key
+   */
+  public String id() {
+    return id;
+  }
+}


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Backport of the reload of jwks. The API is not documented as it just ensures the deprecated API behaves like on master. On 4.0.0 the new API is called `jwkSet` to follow the oidc spec naming.