### PR TITLE
Fix public key bug in KeycloakAuth

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/KeycloakAuth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/KeycloakAuth.java
@@ -109,7 +109,7 @@ public interface KeycloakAuth extends OpenIDConnectAuth {
     if (config.containsKey("realm-public-key")) {
       options.addPubSecKey(new PubSecKeyOptions()
         .setAlgorithm("RS256")
-        .setPublicKey(config.getString("realm-public-key")));
+        .setBuffer(config.getString("realm-public-key")));
     }
 
     return OAuth2Auth


### PR DESCRIPTION
The `setPublicKey` method was being used even though it is deprecated. This was causing an error for me. Updating it to use `setBuffer` fixed the issue.

Note that `realm-public-key` should now start with `-----BEGIN PUBLIC KEY-----` and end with `-----END PUBLIC KEY-----`.
