### PR TITLE
Support leeway for oauth2 user expiry check

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2UserImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2UserImpl.java
@@ -247,6 +247,8 @@ public abstract class OAuth2UserImpl extends AbstractUser implements AccessToken
    */
   @Override
   public boolean expired() {
+    int leeway = 0;
+
     if (principal == null) {
       return true;
     }
@@ -255,6 +257,7 @@ public abstract class OAuth2UserImpl extends AbstractUser implements AccessToken
       // delegate to the JWT lib
       final JWT jwt = provider.getJWT();
       final JWTOptions options = provider.getConfig().getJWTOptions();
+      leeway = options.getLeeway() * 1000;
       try {
         jwt.isExpired(accessToken, options);
       } catch (RuntimeException e) {
@@ -266,7 +269,7 @@ public abstract class OAuth2UserImpl extends AbstractUser implements AccessToken
 
     long now = System.currentTimeMillis();
     // expires_at is a computed field always in millis
-    if (principal.containsKey("expires_at") && principal.getLong("expires_at", 0L) < now) {
+    if (principal.containsKey("expires_at") && principal.getLong("expires_at", 0L) < now - leeway) {
       return true;
     }
 


### PR DESCRIPTION
In most cases of JWT token expiry checking a leeway option is support.
This fix also supports it when doing oauth2 user token validation.

Fixes #431

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
