### PR TITLE
fix: UserConverter does not consider attributes

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/UserConverter.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/UserConverter.java
@@ -24,6 +24,7 @@ public class UserConverter {
 
   private final static String FIELD_PRINCIPAL = "principal";
   private final static String FIELD_AUTHORIZATIONS = "authorizations";
+  private final static String FIELD_ATTRIBUTES = "attributes";
 
   public static JsonObject encode(User value) throws IllegalArgumentException {
     Objects.requireNonNull(value);
@@ -39,6 +40,7 @@ public class UserConverter {
       }
     }
     json.put(FIELD_AUTHORIZATIONS, jsonAuthorizations);
+    json.put(FIELD_ATTRIBUTES, value.attributes());
     return json;
   }
 
@@ -56,6 +58,7 @@ public class UserConverter {
         user.authorizations().add(fieldName, AuthorizationConverter.decode(jsonAuthorization));
       }
     }
+    user.attributes().mergeIn(json.getJsonObject(FIELD_ATTRIBUTES, new JsonObject()));
     return user;
   }
 

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/UserTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/UserTest.java
@@ -32,7 +32,10 @@ public class UserTest {
   }
 
   public User createTestUser() {
-    return User.create(new JsonObject().put("principal1", "value principal 1").put("principal2", "value principal 2"));
+    return User.create(
+      new JsonObject().put("principal1", "value principal 1").put("principal2", "value principal 2"),
+      new JsonObject().put("attribute1", "value attribute 1").put("attribute2", "value attribute 2")
+    );
   }
 
   @Test


### PR DESCRIPTION
Motivation:

When encoding/decoding the User (in this case via ClusteredSessionStore), the attributes of a User is lost upon encoding, and therefore not available after decoding.