### PR TITLE
don't duplicate headers for oauth2

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
@@ -172,11 +172,6 @@ public class OAuth2API {
       headers.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes(StandardCharsets.UTF_8)));
     }
 
-    JsonObject tmp = config.getHeaders();
-    if (tmp != null) {
-      headers.mergeIn(tmp);
-    }
-
     // Enable the system to send authorization params in the body (for example github does not require to be in the header)
     final JsonObject form = params.copy();
     if (config.getExtraParameters() != null) {
@@ -262,11 +257,6 @@ public class OAuth2API {
       headers.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes(StandardCharsets.UTF_8)));
     }
 
-    JsonObject tmp = config.getHeaders();
-    if (tmp != null) {
-      headers.mergeIn(tmp);
-    }
-
     final JsonObject form = new JsonObject()
       .put("token", token)
       // optional param from RFC7662
@@ -347,11 +337,6 @@ public class OAuth2API {
     if (confidentialClient) {
       String basic = config.getClientID() + ":" + config.getClientSecret();
       headers.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes(StandardCharsets.UTF_8)));
-    }
-
-    final JsonObject tmp = config.getHeaders();
-    if (tmp != null) {
-      headers.mergeIn(tmp);
     }
 
     final JsonObject form = new JsonObject();
@@ -492,12 +477,6 @@ public class OAuth2API {
     final JsonObject headers = new JsonObject();
 
     headers.put("Authorization", "Bearer " + accessToken);
-
-    JsonObject tmp = config.getHeaders();
-
-    if (tmp != null) {
-      headers.mergeIn(tmp);
-    }
 
     final JsonObject form = new JsonObject();
 

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AccessTokenTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AccessTokenTest.java
@@ -68,11 +68,13 @@ public class OAuth2AccessTokenTest extends VertxTestBase {
       .setFlow(OAuth2FlowType.AUTH_CODE)
       .setClientID("client-id")
       .setClientSecret("client-secret")
-      .setSite("http://localhost:8080"));
+      .setSite("http://localhost:8080")
+      .setHeaders(new JsonObject().put("x-foo", "bar")));
 
     final CountDownLatch latch = new CountDownLatch(1);
 
     server = vertx.createHttpServer().requestHandler(req -> {
+      assertEquals("bar", req.getHeader("x-foo"));
       if (req.method() == HttpMethod.POST && "/oauth/token".equals(req.path())) {
         assertEquals("Basic Y2xpZW50LWlkOmNsaWVudC1zZWNyZXQ=", req.getHeader("Authorization"));
         req.setExpectMultipart(true).bodyHandler(buffer -> {


### PR DESCRIPTION
The following `OAuth2API` methods add configured headers to the request and subsequently call `fetch` which *also* adds the configured headers to the request, resulting in duplicate headers as described in Issue #444:

* `token`
* `tokenIntrospection`
* `tokenRevocation`
* `logout`

This PR removes the header-adding code from these methods.