### PR TITLE
Change error message for expired jwt token

### DIFF
--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
@@ -158,7 +158,7 @@ public class JWTAuthProviderImpl implements JWTAuth {
 
       if (user.expired(jwtOptions.getLeeway())) {
         if (!jwtOptions.isIgnoreExpiration()) {
-          resultHandler.handle(Future.failedFuture("Invalid JWT token: missing required scopes."));
+          resultHandler.handle(Future.failedFuture("Invalid JWT token: token expired."));
           return;
         }
       }


### PR DESCRIPTION
Motivation:

The current error message _Invalid JWT token: missing required scopes._ is miss-leading as it does not inform about the expired token. 