### PR TITLE
Get the scope from the user not the principal

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/ScopeAuthorizationImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/ScopeAuthorizationImpl.java
@@ -43,7 +43,7 @@ public class ScopeAuthorizationImpl implements ScopeAuthorization {
 
   @Override
   public void getAuthorizations(User user, Handler<AsyncResult<Void>> handler) {
-    String scopes = user.principal().getString("scope");
+    String scopes = user.get("scope");
 
     final Set<Authorization> authorizations = new HashSet<>();
 


### PR DESCRIPTION
Depending on the AuthenticationProvider impl the scope may not be in the principal. Instead use the User#get method which checks multiple locations. This allows for the ScopeAuthorization to be used in conjunction with the OAuth2Auth.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
