### PR TITLE
Secret materials encoded as string assume UTF8 instead of US_ASCII

### DIFF
--- a/vertx-auth-common/src/main/generated/io/vertx/ext/auth/PubSecKeyOptionsConverter.java
+++ b/vertx-auth-common/src/main/generated/io/vertx/ext/auth/PubSecKeyOptionsConverter.java
@@ -23,7 +23,7 @@ public class PubSecKeyOptionsConverter {
           break;
         case "buffer":
           if (member.getValue() instanceof String) {
-            obj.setBuffer((String)member.getValue());
+            obj.setBuffer(io.vertx.core.buffer.Buffer.buffer(JsonUtil.BASE64_DECODER.decode((String)member.getValue())));
           }
           break;
         case "certificate":
@@ -64,7 +64,7 @@ public class PubSecKeyOptionsConverter {
       json.put("algorithm", obj.getAlgorithm());
     }
     if (obj.getBuffer() != null) {
-      json.put("buffer", obj.getBuffer());
+      json.put("buffer", JsonUtil.BASE64_ENCODER.encodeToString(obj.getBuffer().getBytes()));
     }
     json.put("certificate", obj.isCertificate());
     if (obj.getId() != null) {

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
@@ -1,6 +1,8 @@
 package io.vertx.ext.auth;
 
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.GenIgnore;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 
 /**
@@ -12,7 +14,7 @@ import io.vertx.core.json.JsonObject;
 public class PubSecKeyOptions {
 
   private String algorithm;
-  private String buffer;
+  private Buffer buffer;
   private String id;
 
   private boolean certificate;
@@ -72,7 +74,7 @@ public class PubSecKeyOptions {
    *
    * @return the buffer.
    */
-  public String getBuffer() {
+  public Buffer getBuffer() {
     return buffer;
   }
 
@@ -82,7 +84,19 @@ public class PubSecKeyOptions {
    * payload.
    * @return self.
    */
+  @GenIgnore(GenIgnore.PERMITTED_TYPE)
   public PubSecKeyOptions setBuffer(String buffer) {
+    this.buffer = Buffer.buffer(buffer, "UTF-8");
+    return this;
+  }
+
+  /**
+   * The PEM or Secret key buffer. When working with secret materials, the material is expected to be encoded in
+   * {@code UTF-8}. PEM files are expected to be {@code US_ASCII} as the format uses a base64 encoding for the
+   * payload.
+   * @return self.
+   */
+  public PubSecKeyOptions setBuffer(Buffer buffer) {
     this.buffer = buffer;
     return this;
   }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
@@ -66,7 +66,10 @@ public class PubSecKeyOptions {
   }
 
   /**
-   * The PEM or Secret key buffer
+   * The PEM or Secret key buffer. When working with secret materials, the material is expected to be encoded in
+   * {@code UTF-8}. PEM files are expected to be {@code US_ASCII} as the format uses a base64 encoding for the
+   * payload.
+   *
    * @return the buffer.
    */
   public String getBuffer() {
@@ -74,7 +77,9 @@ public class PubSecKeyOptions {
   }
 
   /**
-   * The PEM or Secret key buffer
+   * The PEM or Secret key buffer. When working with secret materials, the material is expected to be encoded in
+   * {@code UTF-8}. PEM files are expected to be {@code US_ASCII} as the format uses a base64 encoding for the
+   * payload.
    * @return self.
    */
   public PubSecKeyOptions setBuffer(String buffer) {

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
@@ -170,9 +170,9 @@ public final class JWK implements Crypto {
     alg = options.getAlgorithm();
     kid = options.getId();
 
-    final String secret = Objects.requireNonNull(options.getBuffer());
+    final Buffer buffer = Objects.requireNonNull(options.getBuffer());
 
-    label = kid == null ? alg + "#" + secret.hashCode() : kid;
+    label = kid == null ? alg + "#" + buffer.hashCode() : kid;
 
     // Handle Mac keys
 
@@ -180,7 +180,7 @@ public final class JWK implements Crypto {
       case "HS256":
         try {
           mac = Mac.getInstance("HMacSHA256");
-          mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HMacSHA256"));
+          mac.init(new SecretKeySpec(buffer.getBytes(), "HMacSHA256"));
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
           throw new RuntimeException(e);
         }
@@ -193,7 +193,7 @@ public final class JWK implements Crypto {
       case "HS384":
         try {
           mac = Mac.getInstance("HMacSHA384");
-          mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HMacSHA384"));
+          mac.init(new SecretKeySpec(buffer.getBytes(), "HMacSHA384"));
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
           throw new RuntimeException(e);
         }
@@ -206,7 +206,7 @@ public final class JWK implements Crypto {
       case "HS512":
         try {
           mac = Mac.getInstance("HMacSHA512");
-          mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HMacSHA512"));
+          mac.init(new SecretKeySpec(buffer.getBytes(), "HMacSHA512"));
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
           throw new RuntimeException(e);
         }
@@ -228,7 +228,7 @@ public final class JWK implements Crypto {
         case "RS384":
         case "RS512":
           kty = "RSA";
-          use = parsePEM(KeyFactory.getInstance("RSA"), secret);
+          use = parsePEM(KeyFactory.getInstance("RSA"), buffer.toString(StandardCharsets.US_ASCII));
           signature = JWS.getSignature(alg);
           len = JWS.getSignatureLength(alg, publicKey);
           break;
@@ -236,7 +236,7 @@ public final class JWK implements Crypto {
         case "PS384":
         case "PS512":
           kty = "RSASSA";
-          use = parsePEM(KeyFactory.getInstance("RSA"), secret);
+          use = parsePEM(KeyFactory.getInstance("RSA"), buffer.toString(StandardCharsets.US_ASCII));
           signature = JWS.getSignature(alg);
           len = JWS.getSignatureLength(alg, publicKey);
           break;
@@ -246,7 +246,7 @@ public final class JWK implements Crypto {
         case "ES256K":
           kty = "EC";
           len = JWS.getSignatureLength(alg, publicKey);
-          use = parsePEM(KeyFactory.getInstance("EC"), secret);
+          use = parsePEM(KeyFactory.getInstance("EC"), buffer.toString(StandardCharsets.US_ASCII));
           signature = JWS.getSignature(alg);
           break;
         default:

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
@@ -170,9 +170,9 @@ public final class JWK implements Crypto {
     alg = options.getAlgorithm();
     kid = options.getId();
 
-    final String pem = Objects.requireNonNull(options.getBuffer());
+    final String secret = Objects.requireNonNull(options.getBuffer());
 
-    label = kid == null ? alg + "#" + pem.hashCode() : kid;
+    label = kid == null ? alg + "#" + secret.hashCode() : kid;
 
     // Handle Mac keys
 
@@ -180,7 +180,7 @@ public final class JWK implements Crypto {
       case "HS256":
         try {
           mac = Mac.getInstance("HMacSHA256");
-          mac.init(new SecretKeySpec(pem.getBytes(StandardCharsets.US_ASCII), "HMacSHA256"));
+          mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HMacSHA256"));
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
           throw new RuntimeException(e);
         }
@@ -193,7 +193,7 @@ public final class JWK implements Crypto {
       case "HS384":
         try {
           mac = Mac.getInstance("HMacSHA384");
-          mac.init(new SecretKeySpec(pem.getBytes(StandardCharsets.US_ASCII), "HMacSHA384"));
+          mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HMacSHA384"));
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
           throw new RuntimeException(e);
         }
@@ -206,7 +206,7 @@ public final class JWK implements Crypto {
       case "HS512":
         try {
           mac = Mac.getInstance("HMacSHA512");
-          mac.init(new SecretKeySpec(pem.getBytes(StandardCharsets.US_ASCII), "HMacSHA512"));
+          mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HMacSHA512"));
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
           throw new RuntimeException(e);
         }
@@ -228,7 +228,7 @@ public final class JWK implements Crypto {
         case "RS384":
         case "RS512":
           kty = "RSA";
-          use = parsePEM(KeyFactory.getInstance("RSA"), pem);
+          use = parsePEM(KeyFactory.getInstance("RSA"), secret);
           signature = JWS.getSignature(alg);
           len = JWS.getSignatureLength(alg, publicKey);
           break;
@@ -236,7 +236,7 @@ public final class JWK implements Crypto {
         case "PS384":
         case "PS512":
           kty = "RSASSA";
-          use = parsePEM(KeyFactory.getInstance("RSA"), pem);
+          use = parsePEM(KeyFactory.getInstance("RSA"), secret);
           signature = JWS.getSignature(alg);
           len = JWS.getSignatureLength(alg, publicKey);
           break;
@@ -246,7 +246,7 @@ public final class JWK implements Crypto {
         case "ES256K":
           kty = "EC";
           len = JWS.getSignatureLength(alg, publicKey);
-          use = parsePEM(KeyFactory.getInstance("EC"), pem);
+          use = parsePEM(KeyFactory.getInstance("EC"), secret);
           signature = JWS.getSignature(alg);
           break;
         default:


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Fixes #448 

Secret materials should assume UTF8 instead of US_ASCII