### PR TITLE
Fixes #453: alg isn't official listed but needed for metadata checks.…

### DIFF
--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/AppleAttestation.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/AppleAttestation.java
@@ -99,10 +99,17 @@ public class AppleAttestation implements Attestation {
         throw new AttestationException("credCert public key does not equal authData public key");
       }
 
+      // https://w3c.github.io/webauthn/#sctn-apple-anonymous-attestation
+      // the spec doesn't list "alg" yet devices do send it in some cases.
+      // the "alg" is important to support metadata in the future if a device gets blacklisted.
+      final PublicKeyCredential alg = attStmt.containsKey("alg") ?
+        PublicKeyCredential.valueOf(attStmt.getInteger("alg")) :
+        null;
+
       // meta data check
       metadata.verifyMetadata(
         authData.getAaguidString(),
-        PublicKeyCredential.valueOf(attStmt.getInteger("alg")),
+        alg,
         certChain);
 
 


### PR DESCRIPTION
… Some devices do send them, so it should be handled as optional

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fix #453 

Apple verification doesn't mandate a "alg" field.