### PR TITLE
hash PBKDF2: fix interations parsing

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/hash/PBKDF2.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/hash/PBKDF2.java
@@ -66,7 +66,7 @@ public class PBKDF2 implements HashingAlgorithm {
 
     try {
       if (hashString.params() != null) {
-        iterations = Integer.getInteger(hashString.params().get("it"));
+        iterations = Integer.parseInt(hashString.params().get("it"));
       } else {
         iterations = DEFAULT_ITERATIONS;
       }

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/HashingStrategyTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/HashingStrategyTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.HashMap;
 
 import static org.junit.Assert.*;
 
@@ -57,5 +58,15 @@ public class HashingStrategyTest {
     assertTrue(strategy.verify(hash, "SuperSecret$!"));
     // should be wrong
     assertFalse(strategy.verify(hash, "superSecret$!"));
+    HashMap<String, String> params = new HashMap<String, String>();
+    params.put("it", "100000");
+    String hashWithPararms = strategy.hash("pbkdf2", params, salt, "SuperSecret$!");
+    // should be different
+    assertNotEquals(hash, hashWithPararms);
+    // should be valid
+    assertTrue(strategy.verify(hash, "SuperSecret$!"));
+    // should be wrong
+    assertFalse(strategy.verify(hash, "superSecret$!"));
+
   }
 }


### PR DESCRIPTION
Motivation:

Iterations parameters for PBKDF2 is not properly parsed


