### PR TITLE
Fix invalid redirectUri key name for authentication

### DIFF
--- a/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
+++ b/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
@@ -63,7 +63,7 @@ public class AuthOAuth2Examples {
     oauth2.authenticate(
       new JsonObject()
         .put("code", code)
-        .put("redirect_uri", "http://localhost:8080/callback"))
+        .put("redirectUri", "http://localhost:8080/callback"))
       .onSuccess(user -> {
         // save the token and continue...
       })
@@ -98,7 +98,7 @@ public class AuthOAuth2Examples {
 
     JsonObject tokenConfig = new JsonObject()
       .put("code", "<code>")
-      .put("redirect_uri", "http://localhost:3000/callback");
+      .put("redirectUri", "http://localhost:3000/callback");
 
     // Callbacks
     // Save the access token


### PR DESCRIPTION
'redirect_uri' doesn't work as key if used with the authenticate method.

This change will replace 'redirect_uri' with 'redirectUri' if used with the authenticate method,
but will keep 'redirect_uri' if used with the authorizeURL method.

Here is the test code for the OAuth2 Auth Code flow, that does the same thing:
https://github.com/vert-x3/vertx-auth/blob/master/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2AuthCodeTest.java
