### PR TITLE
Keep user attributes while merge in results of a chain authentication handler

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/ChainAuthImpl.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/ChainAuthImpl.java
@@ -83,7 +83,7 @@ public class ChainAuthImpl implements ChainAuth {
           resultHandler.handle(res);
         } else {
           // if ALL then a success check the next one
-          iterate(idx + 1, authInfo, resultHandler, previousUser == null ? res.result() : User.create(previousUser.principal().mergeIn(res.result().principal())));
+          iterate(idx + 1, authInfo, resultHandler, merge(previousUser, res.result()));
         }
       } else {
         // try again with next provider
@@ -97,5 +97,15 @@ public class ChainAuthImpl implements ChainAuth {
         }
       }
     });
+  }
+
+  private User merge(User previousUser, User resultUser) {
+    if(previousUser==null) {
+      return resultUser;
+    }
+    return User.create(
+      previousUser.principal().mergeIn(resultUser.principal()),
+      previousUser.attributes().mergeIn(resultUser.attributes())
+    );
   }
 }

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/ChainAuthTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/ChainAuthTest.java
@@ -167,17 +167,20 @@ public class ChainAuthTest {
 
     auth.add((authInfo, res) -> {
       // always OK
-      res.handle(Future.succeededFuture(createUser(new JsonObject().put("provider", 1))));
+      res.handle(Future.succeededFuture(User.create(new JsonObject().put("provider", 1), new JsonObject().put("attribute", "one"))));
     });
 
     auth.add((authInfo, res) -> {
       // always OK
-      res.handle(Future.succeededFuture(createUser(new JsonObject().put("provider", 2))));
+      res.handle(Future.succeededFuture(User.create(new JsonObject().put("provider", 2), new JsonObject().put("attribute", "two"))));
     });
 
     auth.authenticate(new JsonObject(), res -> {
       if (res.succeeded()) {
+        User result = res.result();
+        should.assertNotNull(result);
         should.assertEquals(2, res.result().principal().getInteger("provider").intValue());
+        should.assertEquals("two",res.result().attributes().getString("attribute"));
         test.complete();
       } else {
         should.fail();


### PR DESCRIPTION

# Motivation

As mentioned here #483 , I meet some issues while upgrading to the 4.1.0

With the last release, the JwtAuthHandlerImpl has setup a [postAuthentication](https://github.com/vert-x3/vertx-web/blob/master/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/JWTAuthHandlerImpl.java#L117) based on a `accessToken` retrieved from the user context.

This `accessToken` is [injected into the user attributes](https://github.com/vert-x3/vertx-auth/blob/master/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java#L154) when the JWTAuth succeed.

But in the case of chain auth, [only the user principal is merged](https://github.com/vert-x3/vertx-auth/blob/master/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/ChainAuthImpl.java#L86), not the attributes.

As a consequence, the upgrade from 4.0.3 to 4.1.0 was failing on my side.

Please note that I have a custom Chain Handler (because currently there is no easy way to chain two JWTAuth, but reported my fix here in case there are some other issues related to missing user attributes.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
