### PR TITLE
Bump commons-codec from 1.11 to 1.15

### DIFF
--- a/vertx-auth-htpasswd/pom.xml
+++ b/vertx-auth-htpasswd/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.14</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/vertx-auth-htpasswd/pom.xml
+++ b/vertx-auth-htpasswd/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.11</version>
+      <version>1.14</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>


### PR DESCRIPTION
#### Motivation:

Version 1.14 includes a fix for improper base32 and base64 decoding.

https://issues.apache.org/jira/browse/CODEC-134
https://issues.apache.org/jira/browse/CODEC-270