### PR TITLE
Fixes #492: removed superflous if statement

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -156,11 +156,12 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
     }
 
     final OAuth2FlowType flow = config.getFlow();
+    final Oauth2Credentials cred;
 
     switch (flow) {
       case AUTH_CODE:
         if (authInfo.containsKey("code")) {
-          Oauth2Credentials cred = new Oauth2Credentials()
+          cred = new Oauth2Credentials()
             .setCode(authInfo.getString("code"))
             .setCodeVerifier(authInfo.getString("codeVerifier"))
             .setRedirectUri(authInfo.getString("redirectUri"));
@@ -170,23 +171,20 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
         }
         break;
       case CLIENT:
-        if (authInfo.size() == 0) {
-          Oauth2Credentials cred = new Oauth2Credentials();
+        cred = new Oauth2Credentials();
 
-          if (authInfo.containsKey("scopes")) {
-            for (Object scope : authInfo.getJsonArray("scopes")) {
-              cred.addScope((String) scope);
-            }
+        if (authInfo.containsKey("scopes")) {
+          for (Object scope : authInfo.getJsonArray("scopes")) {
+            cred.addScope((String) scope);
           }
-
-          authenticate(cred, handler);
-          return;
         }
-        break;
+
+        authenticate(cred, handler);
+        return;
       case PASSWORD:
         if (authInfo.containsKey("username") && authInfo.containsKey("password")) {
 
-          Oauth2Credentials cred = new Oauth2Credentials()
+          cred = new Oauth2Credentials()
             .setUsername(authInfo.getString("username"))
             .setPassword(authInfo.getString("password"));
 
@@ -203,7 +201,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
       case AUTH_JWT:
       case AAD_OBO:
         if (authInfo.containsKey("assertion")) {
-          Oauth2Credentials cred = new Oauth2Credentials()
+          cred = new Oauth2Credentials()
             .setAssertion(authInfo.getString("assertion"));
 
           authenticate(cred, handler);
@@ -222,7 +220,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
   /**
    * OAuth2/OIDC authentication. Authentication in this object means, checking if the given credentials are valid by
    * verifying them with the IdP or doing a cryptographic check of the credentials.
-   *
+   * <p>
    * Depending on the flow in use, different credential objects can be used in this method.
    *
    * <ul>
@@ -237,7 +235,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth {
    *   {@code access_token} in order to perform a action on behalf of the user.</li>
    *   <li>{@code IMPLICIT} - The implicit flow has been deprecated by OAuth2 and was never supported by this module.</li>
    * </ul>
-   *
+   * <p>
    * This means that different {@link Credentials} types can be used.
    *
    * <ul>

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ClientTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ClientTest.java
@@ -2,6 +2,7 @@ package io.vertx.ext.auth.test.oauth2;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.http.SimpleHttpClient;
@@ -28,6 +29,10 @@ public class OAuth2ClientTest extends VertxTestBase {
 
   private static final JsonObject oauthConfig = new JsonObject()
     .put("grant_type", "client_credentials");
+
+  private static final JsonObject oauthConfigWithScopes = new JsonObject()
+    .put("grant_type", "client_credentials")
+    .put("scope", "scopeA");
 
   protected OAuth2Auth oauth2;
   private HttpServer server;
@@ -79,6 +84,22 @@ public class OAuth2ClientTest extends VertxTestBase {
   public void getToken() {
     config = oauthConfig;
     oauth2.authenticate(tokenConfig, res -> {
+      if (res.failed()) {
+        fail(res.cause().getMessage());
+      } else {
+        User token = res.result();
+        assertNotNull(token);
+        assertNotNull(token.principal());
+        testComplete();
+      }
+    });
+    await();
+  }
+
+  @Test
+  public void getTokenWithScopes() {
+    config = oauthConfigWithScopes;
+    oauth2.authenticate(new JsonObject().put("scopes", new JsonArray().add("scopeA")), res -> {
       if (res.failed()) {
         fail(res.cause().getMessage());
       } else {


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fixes #492 : Client Credentials flow doesn't require any config, but may receive scopes so the if statement wasn't correct.