### PR TITLE
Use configured custom property names

### DIFF
--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthenticationImpl.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthenticationImpl.java
@@ -77,7 +77,11 @@ public class MongoAuthenticationImpl implements MongoAuthentication {
 
   @Override
   public void authenticate(JsonObject credentials, Handler<AsyncResult<User>> resultHandler) {
-    authenticate(new UsernamePasswordCredentials(credentials), resultHandler);
+    authenticate(
+        new UsernamePasswordCredentials(
+            credentials.getString(options.getUsernameCredentialField()),
+            credentials.getString(options.getPasswordCredentialField())),
+        resultHandler);
   }
 
   @Override
@@ -143,7 +147,7 @@ public class MongoAuthenticationImpl implements MongoAuthentication {
     case 1: {
       JsonObject json = resultList.result().get(0);
       User user = createUser(json);
-      if (examinePassword(user, json.getString(options.getPasswordCredentialField()), authToken.password))
+      if (examinePassword(user, json.getString(options.getPasswordField()), authToken.password))
         return user;
       else {
         String message = "Invalid username/password [" + authToken.username + "]";

--- a/vertx-auth-mongo/src/test/java/io/vertx/ext/auth/mongo/test/MongoBaseTest.java
+++ b/vertx-auth-mongo/src/test/java/io/vertx/ext/auth/mongo/test/MongoBaseTest.java
@@ -219,7 +219,7 @@ public abstract class MongoBaseTest extends VertxTestBase {
     user.put(authenticationOptions.getUsernameField(), username);
     user.put(authenticationOptions.getPasswordField(), hashedPassword);
 
-    Promise promise = Promise.promise();
+    Promise<String> promise = Promise.promise();
     getMongoClient().save(authenticationOptions.getCollectionName(), user, promise);
     return promise.future();
   }


### PR DESCRIPTION
This is for #506
 
The MongoAuthenticationImpl class did not properly consider the (custom)
field names set on MongoAuthenticationOptions.
