### PR TITLE
Avoid duplication with codecs

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/PRNG.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/PRNG.java
@@ -19,8 +19,9 @@ import io.vertx.core.Vertx;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.Base64;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.vertx.ext.auth.impl.Codec.base64UrlEncode;
 
 /**
  * Wrapper around secure random that periodically seeds the PRNG with new entropy. To avoid entropy exhaustion
@@ -33,8 +34,6 @@ public class PRNG implements VertxContextPRNG {
 
   private static final int DEFAULT_SEED_INTERVAL_MILLIS = 300000;
   private static final int DEFAULT_SEED_BITS = 64;
-
-  private static final Base64.Encoder base64url = Base64.getUrlEncoder().withoutPadding();
 
   private final SecureRandom random;
   private final long seedID;
@@ -178,7 +177,7 @@ public class PRNG implements VertxContextPRNG {
     // fill with random data
     nextBytes(data);
     // encode
-    return base64url.encodeToString(data);
+    return base64UrlEncode(data);
   }
 
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/Codec.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/Codec.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.auth.impl;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * A collection of simple codecs to avoid code duplication across modules.
+ *
+ * This helper provies codecs for Base16, Base32 and Base64.
+ *
+ * @author Paulo Lopes
+ */
+public final class Codec {
+
+  private Codec() {
+  }
+
+  private static final byte[] BASE16 = "0123456789abcdef".getBytes(StandardCharsets.US_ASCII);
+  private static final int[] BASE16_LOOKUP =
+    {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+      0x08, 0x09, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0xFF,
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0xFF
+    };
+
+  private static final char[] BASE32 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567".toCharArray();
+  private static final int[] BASE32_LOOKUP =
+    {0xFF, 0xFF, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+      0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
+      0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+      0x17, 0x18, 0x19, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+      0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
+      0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+      0x17, 0x18, 0x19, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+    };
+
+  private static final Base64.Encoder BASE64URL = Base64.getUrlEncoder().withoutPadding();
+  private static final Base64.Decoder BASE64URL_DECODER = Base64.getUrlDecoder();
+
+  private static final Base64.Encoder BASE64 = Base64.getEncoder();
+  private static final Base64.Encoder BASE64_NOPADDING = Base64.getEncoder().withoutPadding();
+  private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
+
+  public static String base16Encode(byte[] bytes) {
+    byte[] base16 = new byte[bytes.length * 2];
+    for (int i = 0; i < bytes.length; i++) {
+      int v = bytes[i] & 0xFF;
+      base16[i * 2] = BASE16[v >>> 4];
+      base16[i * 2 + 1] = BASE16[v & 0x0F];
+    }
+    return new String(base16);
+  }
+
+  public static byte[] base16Decode(String base16) {
+    int lookup;
+    byte[] bytes = new byte[base16.length() / 2];
+
+    for (int i = 0; i < base16.length(); i += 2) {
+      lookup = base16.charAt(i) - '0';
+      /* chars outside the lookup table */
+      if (lookup < 0 || lookup >= BASE16_LOOKUP.length) {
+        throw new IllegalArgumentException("Invalid char: " + (base16.charAt(i)));
+      }
+      int high = BASE16_LOOKUP[lookup];
+      /* If this digit is not in the table, fail */
+      if (high == 0xFF) {
+        throw new IllegalArgumentException("Invalid char: " + (base16.charAt(i)));
+      }
+
+      lookup = base16.charAt(i + 1) - '0';
+      /* chars outside the lookup table */
+      if (lookup < 0 || lookup >= BASE16_LOOKUP.length) {
+        throw new IllegalArgumentException("Invalid char: " + (base16.charAt(i + 1)));
+      }
+      int low = BASE16_LOOKUP[lookup];
+      /* If this digit is not in the table, fail */
+      if (low == 0xFF) {
+        throw new IllegalArgumentException("Invalid char: " + (base16.charAt(i + 1)));
+      }
+      bytes[i / 2] = (byte) ((high << 4) + low);
+    }
+    return bytes;
+  }
+
+  public static String base32Encode(byte[] bytes) {
+    int i = 0, index = 0, digit;
+    int currByte, nextByte;
+    StringBuilder base32 = new StringBuilder(((bytes.length + 7) * 8 / 5));
+
+    while (i < bytes.length) {
+      currByte = (bytes[i] >= 0) ? bytes[i] : (bytes[i] + 256);
+
+      /* Is the current digit going to span a byte boundary? */
+      if (index > 3) {
+        if ((i + 1) < bytes.length) {
+          nextByte = (bytes[i + 1] >= 0)
+            ? bytes[i + 1] : (bytes[i + 1] + 256);
+        } else {
+          nextByte = 0;
+        }
+
+        digit = currByte & (0xFF >> index);
+        index = (index + 5) % 8;
+        digit <<= index;
+        digit |= nextByte >> (8 - index);
+        i++;
+      } else {
+        digit = (currByte >> (8 - (index + 5))) & 0x1F;
+        index = (index + 5) % 8;
+        if (index == 0)
+          i++;
+      }
+      base32.append(BASE32[digit]);
+    }
+
+    return base32.toString();
+  }
+
+  static public byte[] base32Decode(final String base32) {
+    int i, index, lookup, offset, digit;
+    byte[] bytes = new byte[base32.length() * 5 / 8];
+
+    for (i = 0, index = 0, offset = 0; i < base32.length(); i++) {
+      lookup = base32.charAt(i) - '0';
+
+      /* Fail if chars outside the lookup table */
+      if (lookup < 0 || lookup >= BASE32_LOOKUP.length) {
+        throw new IllegalArgumentException("Invalid char: " + (base32.charAt(i)));
+      }
+
+      digit = BASE32_LOOKUP[lookup];
+
+      /* If this digit is not in the table, fail */
+      if (digit == 0xFF) {
+        throw new IllegalArgumentException("Invalid char: " + (base32.charAt(i)));
+      }
+
+      if (index <= 3) {
+        index = (index + 5) % 8;
+        if (index == 0) {
+          bytes[offset] |= digit;
+          offset++;
+          if (offset >= bytes.length)
+            break;
+        } else {
+          bytes[offset] |= digit << (8 - index);
+        }
+      } else {
+        index = (index + 5) % 8;
+        bytes[offset] |= (digit >>> index);
+        offset++;
+
+        if (offset >= bytes.length) {
+          break;
+        }
+        bytes[offset] |= digit << (8 - index);
+      }
+    }
+    return bytes;
+  }
+
+  public static String base64UrlEncode(byte[] bytes) {
+    return BASE64URL.encodeToString(bytes);
+  }
+
+  public static byte[] base64UrlDecode(String base64) {
+    return BASE64URL_DECODER.decode(base64);
+  }
+
+  public static String base64Encode(byte[] bytes) {
+    return BASE64.encodeToString(bytes);
+  }
+
+  public static String base64EncodeWithoutPadding(byte[] bytes) {
+    return BASE64_NOPADDING.encodeToString(bytes);
+  }
+
+  public static byte[] base64Decode(String base64) {
+    return BASE64_DECODER.decode(base64);
+  }
+}

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/hash/AbstractMDHash.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/hash/AbstractMDHash.java
@@ -22,7 +22,8 @@ import io.vertx.ext.auth.HashingAlgorithm;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
+
+import static io.vertx.ext.auth.impl.Codec.base64EncodeWithoutPadding;
 
 /**
  * Abstract implementation of hashing algorithms based on <code>java.security.MessageDigest</code>.
@@ -30,8 +31,6 @@ import java.util.Base64;
  * @author <a href="mailto:lgao@redhat.com">Lin Gao</a>
  */
 public abstract class AbstractMDHash implements HashingAlgorithm {
-
-  private static final Base64.Encoder B64ENC = Base64.getEncoder().withoutPadding();
 
   private final MessageDigest md;
 
@@ -45,7 +44,7 @@ public abstract class AbstractMDHash implements HashingAlgorithm {
 
   @Override
   public String hash(HashString hashString, String password) {
-    return B64ENC.encodeToString(md.digest(password.getBytes(StandardCharsets.UTF_8)));
+    return base64EncodeWithoutPadding(md.digest(password.getBytes(StandardCharsets.UTF_8)));
   }
 
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/hash/PBKDF2.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/hash/PBKDF2.java
@@ -22,9 +22,11 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Set;
+
+import static io.vertx.ext.auth.impl.Codec.base64Decode;
+import static io.vertx.ext.auth.impl.Codec.base64EncodeWithoutPadding;
 
 /**
  * Implementation of the PBKDF2 Hashing algorithm
@@ -34,8 +36,6 @@ import java.util.Set;
 public class PBKDF2 implements HashingAlgorithm {
 
   private static final int DEFAULT_ITERATIONS = 10000;
-  private static final Base64.Decoder B64DEC = Base64.getDecoder();
-  private static final Base64.Encoder B64ENC = Base64.getEncoder().withoutPadding();
 
   private static final Set<String> DEFAULT_CONFIG = Collections.singleton("it");
 
@@ -78,7 +78,7 @@ public class PBKDF2 implements HashingAlgorithm {
       throw new RuntimeException("hashString salt is null");
     }
 
-    byte[] salt = B64DEC.decode(hashString.salt());
+    byte[] salt = base64Decode(hashString.salt());
 
     PBEKeySpec spec = new PBEKeySpec(
       password.toCharArray(),
@@ -87,7 +87,7 @@ public class PBKDF2 implements HashingAlgorithm {
       64 * 8);
 
     try {
-      return B64ENC.encodeToString(skf.generateSecret(spec).getEncoded());
+      return base64EncodeWithoutPadding(skf.generateSecret(spec).getEncoded());
     } catch (InvalidKeySpecException ikse) {
       throw new RuntimeException(ikse);
     }

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/HashingStrategyTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/HashingStrategyTest.java
@@ -1,5 +1,6 @@
 package io.vertx.ext.auth;
 
+import io.vertx.ext.auth.impl.Codec;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Rule;
@@ -7,7 +8,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.HashMap;
 
 import static org.junit.Assert.*;
@@ -18,9 +18,7 @@ public class HashingStrategyTest {
   @Rule
   public RunTestOnContext rule = new RunTestOnContext();
 
-  Base64.Encoder B64ENC = Base64.getEncoder();
-
-  String salt = B64ENC.encodeToString("keyboard.cat".getBytes(StandardCharsets.UTF_8));
+  String salt = Codec.base64Encode("keyboard.cat".getBytes(StandardCharsets.UTF_8));
 
   @Test
   public void testHashSimple() {

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/impl/CodecTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/impl/CodecTest.java
@@ -1,0 +1,30 @@
+package io.vertx.ext.auth.impl;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+public class CodecTest {
+
+  @Test
+  public void testBase32() {
+    String source = "The quick brown fox jumps over the lazy dog.";
+
+    assertEquals(
+      "KRUGKIDROVUWG2ZAMJZG653OEBTG66BANJ2W24DTEBXXMZLSEB2GQZJANRQXU6JAMRXWOLQ",
+      Codec.base32Encode(source.getBytes(StandardCharsets.UTF_8))
+    );
+  }
+
+  @Test
+  public void testBase16() {
+    byte[] source = "The quick brown fox jumps over the lazy dog.".getBytes(StandardCharsets.UTF_8);
+
+    assertArrayEquals(
+      source,
+      Codec.base16Decode(Codec.base16Encode(source))
+    );
+  }
+}

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/impl/jose/CryptoTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/impl/jose/CryptoTest.java
@@ -3,23 +3,6 @@ package io.vertx.ext.auth.impl.jose;
 import io.vertx.ext.auth.PubSecKeyOptions;
 import org.junit.Test;
 
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyStore;
-import java.security.PrivateKey;
-import java.security.cert.X509Certificate;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.*;
 

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/impl/jose/SignatureHelperTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/impl/jose/SignatureHelperTest.java
@@ -3,15 +3,15 @@ package io.vertx.ext.auth.impl.jose;
 import org.junit.Test;
 
 import java.security.cert.CertificateException;
-import java.util.Base64;
 
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
 import static org.junit.Assert.*;
 
 public class SignatureHelperTest {
 
   @Test
   public void testSignatureHelper() {
-    assertTrue(JWS.isASN1(Base64.getUrlDecoder().decode("MCYCEQDEMaWRBcGQuP-DtlsfNQBHAhEAszOqZ_37oJRbciOwWy3l5Q==")));
+    assertTrue(JWS.isASN1(base64UrlDecode("MCYCEQDEMaWRBcGQuP-DtlsfNQBHAhEAszOqZ_37oJRbciOwWy3l5Q==")));
   }
 
   @Test
@@ -21,12 +21,12 @@ public class SignatureHelperTest {
 
   @Test
   public void testSignatureHelperInvalid() {
-    assertFalse(JWS.isASN1(Base64.getUrlDecoder().decode("MCYCEQDEMaWRBcGQuP-DtlsfNQBHAhEAszOqZ_37oJRbciOwWy3l5QMCYCE")));
+    assertFalse(JWS.isASN1(base64UrlDecode("MCYCEQDEMaWRBcGQuP-DtlsfNQBHAhEAszOqZ_37oJRbciOwWy3l5QMCYCE")));
   }
 
   @Test
   public void testES256Signature() {
-    byte[] signature = Base64.getUrlDecoder().decode("tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA");
+    byte[] signature = base64UrlDecode("tyh-VfuzIxCyGYDlkBA7DfyjrqmSHu6pQ2hoZuFqUSLPNY2N0mpHb3nk5K17HWP_3cYHBw7AhHale5wky6-sVA");
     assertFalse(JWS.isASN1(signature));
     byte[] asn1 = JWS.toASN1(signature);
     assertTrue(JWS.isASN1(asn1));
@@ -35,7 +35,7 @@ public class SignatureHelperTest {
 
   @Test
   public void testES384Signature() {
-    byte[] signature = Base64.getUrlDecoder().decode("cJOP_w-hBqnyTsBm3T6lOE5WpcHaAkLuQGAs1QO-lg2eWs8yyGW8p9WagGjxgvx7h9X72H7pXmXqej3GdlVbFmhuzj45A9SXDOAHZ7bJXwM1VidcPi7ZcrsMSCtP1hiN");
+    byte[] signature = base64UrlDecode("cJOP_w-hBqnyTsBm3T6lOE5WpcHaAkLuQGAs1QO-lg2eWs8yyGW8p9WagGjxgvx7h9X72H7pXmXqej3GdlVbFmhuzj45A9SXDOAHZ7bJXwM1VidcPi7ZcrsMSCtP1hiN");
     assertFalse(JWS.isASN1(signature));
     byte[] asn1 = JWS.toASN1(signature);
     assertTrue(JWS.isASN1(asn1));
@@ -44,7 +44,7 @@ public class SignatureHelperTest {
 
   @Test
   public void testES512Signature() {
-    byte[] signature = Base64.getUrlDecoder().decode("AP_CIMClixc5-BFflmjyh_bRrkloEvwzn8IaWJFfMz13X76PGWF0XFuhjJUjp7EYnSAgtjJ-7iJG4IP7w3zGTBk_AUdmvRCiWp5YAe8S_Hcs8e3gkeYoOxiXFZlSSAx0GfwW1cZ0r67mwGtso1I3VXGkSjH5J0Rk6809bn25GoGRjOPu");
+    byte[] signature = base64UrlDecode("AP_CIMClixc5-BFflmjyh_bRrkloEvwzn8IaWJFfMz13X76PGWF0XFuhjJUjp7EYnSAgtjJ-7iJG4IP7w3zGTBk_AUdmvRCiWp5YAe8S_Hcs8e3gkeYoOxiXFZlSSAx0GfwW1cZ0r67mwGtso1I3VXGkSjH5J0Rk6809bn25GoGRjOPu");
     assertFalse(JWS.isASN1(signature));
     byte[] asn1 = JWS.toASN1(signature);
     assertTrue(JWS.isASN1(asn1));

--- a/vertx-auth-htdigest/src/main/java/io/vertx/ext/auth/htdigest/HtdigestCredentials.java
+++ b/vertx-auth-htdigest/src/main/java/io/vertx/ext/auth/htdigest/HtdigestCredentials.java
@@ -26,6 +26,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.vertx.ext.auth.impl.Codec.base16Encode;
+
 /**
  * Credentials specific to the {@link HtdigestAuth} authentication provider
  *
@@ -322,7 +324,7 @@ public class HtdigestCredentials extends UsernamePasswordCredentials implements 
 
     // Generate response hash
     Buffer response = Buffer.buffer()
-      .appendString(bytesToHex(ha1))
+      .appendString(base16Encode(ha1))
       .appendByte((byte) ':')
       .appendString(nonce);
 
@@ -338,7 +340,7 @@ public class HtdigestCredentials extends UsernamePasswordCredentials implements 
 
     response
       .appendByte((byte) ':')
-      .appendString(bytesToHex(ha2));
+      .appendString(base16Encode(ha2));
 
     Buffer header = Buffer.buffer("Digest ");
 
@@ -356,22 +358,10 @@ public class HtdigestCredentials extends UsernamePasswordCredentials implements 
     }
 
     header
-      .appendString("\", response=\"").appendString(bytesToHex(MD5.digest(response.getBytes())))
+      .appendString("\", response=\"").appendString(base16Encode(MD5.digest(response.getBytes())))
       .appendString("\", opaque=\"").appendString(opaque)
       .appendString("\"");
 
     return header.toString();
-  }
-
-  private final static char[] hexArray = "0123456789abcdef".toCharArray();
-
-  private static String bytesToHex(byte[] bytes) {
-    char[] hexChars = new char[bytes.length * 2];
-    for (int j = 0; j < bytes.length; j++) {
-      int v = bytes[j] & 0xFF;
-      hexChars[j * 2] = hexArray[v >>> 4];
-      hexChars[j * 2 + 1] = hexArray[v & 0x0F];
-    }
-    return new String(hexChars);
   }
 }

--- a/vertx-auth-htdigest/src/main/java/io/vertx/ext/auth/htdigest/impl/HtdigestAuthImpl.java
+++ b/vertx-auth-htdigest/src/main/java/io/vertx/ext/auth/htdigest/impl/HtdigestAuthImpl.java
@@ -33,6 +33,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static io.vertx.ext.auth.impl.Codec.base16Encode;
+
 /**
  * An implementation of {@link HtdigestAuth}
  *
@@ -154,20 +156,8 @@ public class HtdigestAuthImpl implements HtdigestAuth {
     }
   }
 
-  private final static char[] hexArray = "0123456789abcdef".toCharArray();
-
-  private static String bytesToHex(byte[] bytes) {
-    char[] hexChars = new char[bytes.length * 2];
-    for (int j = 0; j < bytes.length; j++) {
-      int v = bytes[j] & 0xFF;
-      hexChars[j * 2] = hexArray[v >>> 4];
-      hexChars[j * 2 + 1] = hexArray[v & 0x0F];
-    }
-    return new String(hexChars);
-  }
-
   private static synchronized String md5(String payload) {
     MD5.reset();
-    return bytesToHex(MD5.digest(payload.getBytes(StandardCharsets.UTF_8)));
+    return base16Encode(MD5.digest(payload.getBytes(StandardCharsets.UTF_8)));
   }
 }

--- a/vertx-auth-htpasswd/src/main/java/io/vertx/ext/auth/htpasswd/impl/hash/SHA1.java
+++ b/vertx-auth-htpasswd/src/main/java/io/vertx/ext/auth/htpasswd/impl/hash/SHA1.java
@@ -21,7 +21,8 @@ import io.vertx.ext.auth.HashingAlgorithm;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
+
+import static io.vertx.ext.auth.impl.Codec.base64Encode;
 
 /**
  * Implementation of the SHA1 Hashing algorithm
@@ -29,8 +30,6 @@ import java.util.Base64;
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
 public class SHA1 implements HashingAlgorithm {
-
-  private static final Base64.Encoder B64ENC = Base64.getEncoder();
 
   private final MessageDigest md;
 
@@ -49,7 +48,7 @@ public class SHA1 implements HashingAlgorithm {
 
   @Override
   public String hash(HashString hashString, String password) {
-    return B64ENC.encodeToString(md.digest(password.getBytes(StandardCharsets.UTF_8)));
+    return base64Encode(md.digest(password.getBytes(StandardCharsets.UTF_8)));
   }
 
   @Override

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/AbstractHashingStrategy.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/AbstractHashingStrategy.java
@@ -5,6 +5,8 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.ext.auth.PRNG;
 import io.vertx.ext.auth.jdbc.JDBCHashStrategy;
 
+import static io.vertx.ext.auth.impl.Codec.base16Encode;
+
 @Deprecated
 public abstract class AbstractHashingStrategy implements JDBCHashStrategy {
 
@@ -20,19 +22,7 @@ public abstract class AbstractHashingStrategy implements JDBCHashStrategy {
     byte[] salt = new byte[32];
     random.nextBytes(salt);
 
-    return bytesToHex(salt);
-  }
-
-  private final char[] HEX_CHARS = "0123456789ABCDEF".toCharArray();
-
-  String bytesToHex(byte[] bytes) {
-    char[] chars = new char[bytes.length * 2];
-    for (int i = 0; i < bytes.length; i++) {
-      int x = 0xFF & bytes[i];
-      chars[i * 2] = HEX_CHARS[x >>> 4];
-      chars[1 + i * 2] = HEX_CHARS[0x0F & x];
-    }
-    return new String(chars);
+    return base16Encode(salt).toUpperCase();
   }
 
   @Override

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/PBKDF2Strategy.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/PBKDF2Strategy.java
@@ -10,6 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 
+import static io.vertx.ext.auth.impl.Codec.base16Encode;
+
 @Deprecated
 public class PBKDF2Strategy extends AbstractHashingStrategy implements JDBCHashStrategy {
 
@@ -52,9 +54,9 @@ public class PBKDF2Strategy extends AbstractHashingStrategy implements JDBCHashS
       byte[] hash = skf.generateSecret(spec).getEncoded();
 
       if (version >= 0) {
-        return bytesToHex(hash) + '$' + version;
+        return base16Encode(hash).toUpperCase() + '$' + version;
       } else {
-        return bytesToHex(hash);
+        return base16Encode(hash).toUpperCase();
       }
 
     } catch (InvalidKeySpecException ikse) {

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/SHA512Strategy.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/SHA512Strategy.java
@@ -8,6 +8,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import static io.vertx.ext.auth.impl.Codec.base16Encode;
+
 @Deprecated
 public class SHA512Strategy extends AbstractHashingStrategy implements JDBCHashStrategy {
 
@@ -42,9 +44,9 @@ public class SHA512Strategy extends AbstractHashingStrategy implements JDBCHashS
 
     byte[] bHash = md.digest(concat.getBytes(StandardCharsets.UTF_8));
     if (version >= 0) {
-      return bytesToHex(bHash) + '$' + version;
+      return base16Encode(bHash).toUpperCase() + '$' + version;
     } else {
-      return bytesToHex(bHash);
+      return base16Encode(bHash).toUpperCase();
     }
   }
 }

--- a/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/jdbc/impl/PBKDF2StrategyTest.java
+++ b/vertx-auth-jdbc/src/test/java/io/vertx/ext/auth/jdbc/impl/PBKDF2StrategyTest.java
@@ -5,6 +5,8 @@ import io.vertx.ext.auth.jdbc.JDBCHashStrategy;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.Test;
 
+import java.util.Locale;
+
 public class PBKDF2StrategyTest extends VertxTestBase {
 
   @Test

--- a/vertx-auth-otp/pom.xml
+++ b/vertx-auth-otp/pom.xml
@@ -40,10 +40,5 @@
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.15</version>
-    </dependency>
   </dependencies>
 </project>

--- a/vertx-auth-otp/src/main/java/io/vertx/ext/auth/otp/OtpKey.java
+++ b/vertx-auth-otp/src/main/java/io/vertx/ext/auth/otp/OtpKey.java
@@ -13,9 +13,11 @@ package io.vertx.ext.auth.otp;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
-import org.apache.commons.codec.binary.Base32;
 
 import java.util.Locale;
+
+import static io.vertx.ext.auth.impl.Codec.base32Decode;
+import static io.vertx.ext.auth.impl.Codec.base32Encode;
 
 /**
  * Key of specific user.
@@ -24,8 +26,6 @@ import java.util.Locale;
  */
 @DataObject
 public class OtpKey {
-
-  private final Base32 BASE32 = new Base32(false);
 
   private String key;
   private String algorithm;
@@ -43,7 +43,7 @@ public class OtpKey {
   }
 
   public OtpKey(byte[] rawKey, String algorithm) {
-    setKey(BASE32.encodeToString(rawKey));
+    setKey(base32Encode(rawKey));
     setAlgorithm(algorithm);
   }
 
@@ -52,7 +52,7 @@ public class OtpKey {
   }
 
   public byte[] getKeyBytes() {
-    return BASE32.decode(key);
+    return base32Decode(key);
   }
 
   public OtpKey setKey(String key) {

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/Authenticator.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/Authenticator.java
@@ -20,8 +20,9 @@ import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 
-import java.util.Base64;
 import java.util.UUID;
+
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
 
 /**
  * Data Object representing an authenticator at rest.
@@ -141,7 +142,7 @@ public class Authenticator {
     if (string == null) {
       return null;
     }
-    Buffer buffer = Buffer.buffer(Base64.getUrlDecoder().decode(string));
+    Buffer buffer = Buffer.buffer(base64UrlDecode(string));
     return new UUID(buffer.getLong(0), buffer.getLong(8));
   }
 

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/AuthData.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/AuthData.java
@@ -26,6 +26,8 @@ import io.vertx.ext.auth.impl.jose.JWK;
 import java.io.IOException;
 import java.util.Map;
 
+import static io.vertx.ext.auth.impl.Codec.base16Encode;
+
 /**
  * FIDO2 Authenticator Data
  * This class decodes the buffer into a parsable object
@@ -36,18 +38,6 @@ public class AuthData {
   public static final int USER_VERIFIED = 0x04;
   public static final int ATTESTATION_DATA = 0x40;
   public static final int EXTENSION_DATA = 0x80;
-
-  private final static char[] HEX = "0123456789abcdef".toCharArray();
-
-  private static String bytesToHex(byte[] bytes) {
-    char[] hexChars = new char[bytes.length * 2];
-    for ( int j = 0; j < bytes.length; j++ ) {
-      int v = bytes[j] & 0xFF;
-      hexChars[j * 2] = HEX[v >>> 4];
-      hexChars[j * 2 + 1] = HEX[v & 0x0F];
-    }
-    return new String(hexChars);
-  }
 
   private final byte[] raw;
 
@@ -120,7 +110,7 @@ public class AuthData {
       aaguid = buffer.getBytes(pos, pos + 16);
       pos += 16;
 
-      String tmp = bytesToHex(aaguid);
+      String tmp = base16Encode(aaguid);
       aaguidString = tmp.substring(0, 8) + "-" + tmp.substring(8, 12)+ "-" + tmp.substring(12, 16) + "-" + tmp.substring(16, 20) + "-" + tmp.substring(20);
 
       int credIDLen = buffer.getUnsignedShort(pos);

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/CBOR.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/CBOR.java
@@ -26,14 +26,15 @@ import io.vertx.core.json.DecodeException;
 import java.io.*;
 import java.util.*;
 
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
+import static io.vertx.ext.auth.impl.Codec.base64UrlEncode;
+
 public final class CBOR {
 
-  private static final Base64.Encoder B64ENC = Base64.getUrlEncoder().withoutPadding();
-  private static final Base64.Decoder B64DEC = Base64.getUrlDecoder();
   private static final CBORFactory FACTORY = new CBORFactory();
 
   public static JsonParser cborParser(String base64) {
-    return cborParser(B64DEC.decode(base64));
+    return cborParser(base64UrlDecode(base64));
   }
 
   public static JsonParser cborParser(byte[] data) {
@@ -70,7 +71,7 @@ public final class CBOR {
       case JsonTokenId.ID_START_ARRAY:
         return parseArray(parser);
       case JsonTokenId.ID_EMBEDDED_OBJECT:
-        return B64ENC.encodeToString(parser.getBinaryValue(Base64Variants.MODIFIED_FOR_URL));
+        return base64UrlEncode(parser.getBinaryValue(Base64Variants.MODIFIED_FOR_URL));
       case JsonTokenId.ID_STRING:
         return parser.getText();
       case JsonTokenId.ID_NUMBER_FLOAT:

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/WebAuthnImpl.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/WebAuthnImpl.java
@@ -44,7 +44,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 import java.util.function.Function;
 
-import static io.vertx.core.json.impl.JsonUtil.BASE64_ENCODER;
+import static io.vertx.ext.auth.impl.Codec.base64UrlEncode;
 import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.hash;
 
 public class WebAuthnImpl implements WebAuthn {
@@ -532,9 +532,9 @@ public class WebAuthnImpl implements WebAuthn {
       return new Authenticator()
         .setFmt(fmt)
         .setAaguid(authData.getAaguidString())
-        .setPublicKey(BASE64_ENCODER.encodeToString(authData.getCredentialPublicKey()))
+        .setPublicKey(base64UrlEncode(authData.getCredentialPublicKey()))
         .setCounter(authData.getSignCounter())
-        .setCredID(BASE64_ENCODER.encodeToString(authData.getCredentialId()))
+        .setCredID(base64UrlEncode(authData.getCredentialId()))
         .setAttestationCertificates(certificates);
     }
   }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Encoding and decoding values from hex, base32 and base64 is a common task across modules, however we have multiple times the same code duplicated. This PR solves the issue by having a single implementation that is shared across all modules.