### PR TITLE
Issues/510

### DIFF
--- a/vertx-auth-common/pom.xml
+++ b/vertx-auth-common/pom.xml
@@ -39,4 +39,43 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.22.0</version>
+        <executions>
+          <execution>
+            <id>legacy-base64-itest</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>io/vertx/ext/auth/it/JWKLegacyBase64Test.java</include>
+              </includes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>router-extended-param-itest</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <systemProperties>
+                <io.vertx.web.route.param.extended-pattern>true</io.vertx.web.route.param.extended-pattern>
+              </systemProperties>
+              <includes>
+                <include>io/vertx/ext/web/it/RouterExtendedParamTest.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authentication/UsernamePasswordCredentials.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authentication/UsernamePasswordCredentials.java
@@ -17,7 +17,8 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
+
+import static io.vertx.ext.auth.impl.Codec.base64Encode;
 
 /**
  * Credentials used by any {@link AuthenticationProvider} that requires tokens, for example JWT, Oauth2, OpenId Connect
@@ -105,7 +106,7 @@ public class UsernamePasswordCredentials implements Credentials {
         ":" +
         (password == null ? "" : password);
 
-    return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    return "Basic " + base64Encode(credentials.getBytes(StandardCharsets.UTF_8));
   }
 
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/Codec.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/Codec.java
@@ -62,6 +62,9 @@ public final class Codec {
   private static final Base64.Encoder BASE64_NOPADDING = Base64.getEncoder().withoutPadding();
   private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
 
+  private static final Base64.Encoder BASE64MIME = Base64.getMimeEncoder();
+  private static final Base64.Decoder BASE64MIME_DECODER = Base64.getMimeDecoder();
+
   public static String base16Encode(byte[] bytes) {
     byte[] base16 = new byte[bytes.length * 2];
     for (int i = 0; i < bytes.length; i++) {
@@ -69,7 +72,7 @@ public final class Codec {
       base16[i * 2] = BASE16[v >>> 4];
       base16[i * 2 + 1] = BASE16[v & 0x0F];
     }
-    return new String(base16);
+    return new String(base16, StandardCharsets.ISO_8859_1);
   }
 
   public static byte[] base16Decode(String base16) {
@@ -188,6 +191,10 @@ public final class Codec {
     return BASE64URL_DECODER.decode(base64);
   }
 
+  public static byte[] base64UrlDecode(byte[] base64) {
+    return BASE64URL_DECODER.decode(base64);
+  }
+
   public static String base64Encode(byte[] bytes) {
     return BASE64.encodeToString(bytes);
   }
@@ -198,5 +205,21 @@ public final class Codec {
 
   public static byte[] base64Decode(String base64) {
     return BASE64_DECODER.decode(base64);
+  }
+
+  public static byte[] base64Decode(byte[] base64) {
+    return BASE64_DECODER.decode(base64);
+  }
+
+  public static String base64MimeEncode(byte[] bytes) {
+    return BASE64MIME.encodeToString(bytes);
+  }
+
+  public static byte[] base64MimeDecode(String base64) {
+    return BASE64MIME_DECODER.decode(base64);
+  }
+
+  public static byte[] base64MimeDecode(byte[] base64) {
+    return BASE64MIME_DECODER.decode(base64);
   }
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
@@ -36,6 +36,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.vertx.ext.auth.impl.Codec.base64MimeDecode;
 import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
 
 /**
@@ -278,12 +279,12 @@ public final class JWK {
       case "PUBLIC KEY":
       case "PUBLIC RSA KEY":
       case "RSA PUBLIC KEY":
-        publicKey = kf.generatePublic(new X509EncodedKeySpec(Base64.getMimeDecoder().decode(buffer.getBytes())));
+        publicKey = kf.generatePublic(new X509EncodedKeySpec(base64MimeDecode(buffer.getBytes())));
         return;
       case "PRIVATE KEY":
       case "PRIVATE RSA KEY":
       case "RSA PRIVATE KEY":
-        privateKey = kf.generatePrivate(new PKCS8EncodedKeySpec(Base64.getMimeDecoder().decode(buffer.getBytes())));
+        privateKey = kf.generatePrivate(new PKCS8EncodedKeySpec(base64MimeDecode(buffer.getBytes())));
         return;
       default:
         throw new IllegalStateException("Invalid PEM content: " + kind);

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
@@ -36,6 +36,8 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
+
 /**
  * JWK https://tools.ietf.org/html/rfc7517
  * <p>
@@ -440,17 +442,17 @@ public final class JWK {
   private void createRSA(JsonObject json) throws NoSuchAlgorithmException, InvalidKeySpecException, CertificateException, InvalidKeyException, NoSuchProviderException, SignatureException {
     // public key
     if (jsonHasProperties(json, "n", "e")) {
-      final BigInteger n = new BigInteger(1, json.getBinary("n"));
-      final BigInteger e = new BigInteger(1, json.getBinary("e"));
+      final BigInteger n = new BigInteger(1, base64UrlDecode(json.getString("n")));
+      final BigInteger e = new BigInteger(1, base64UrlDecode(json.getString("e")));
       publicKey = KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(n, e));
       // private key
       if (jsonHasProperties(json, "d", "p", "q", "dp", "dq", "qi")) {
-        final BigInteger d = new BigInteger(1, json.getBinary("d"));
-        final BigInteger p = new BigInteger(1, json.getBinary("p"));
-        final BigInteger q = new BigInteger(1, json.getBinary("q"));
-        final BigInteger dp = new BigInteger(1, json.getBinary("dp"));
-        final BigInteger dq = new BigInteger(1, json.getBinary("dq"));
-        final BigInteger qi = new BigInteger(1, json.getBinary("qi"));
+        final BigInteger d = new BigInteger(1, base64UrlDecode(json.getString("d")));
+        final BigInteger p = new BigInteger(1, base64UrlDecode(json.getString("p")));
+        final BigInteger q = new BigInteger(1, base64UrlDecode(json.getString("q")));
+        final BigInteger dp = new BigInteger(1, base64UrlDecode(json.getString("dp")));
+        final BigInteger dq = new BigInteger(1, base64UrlDecode(json.getString("dq")));
+        final BigInteger qi = new BigInteger(1, base64UrlDecode(json.getString("qi")));
 
         privateKey = KeyFactory.getInstance("RSA").generatePrivate(new RSAPrivateCrtKeySpec(n, e, d, p, q, dp, dq, qi));
       }
@@ -481,14 +483,14 @@ public final class JWK {
 
     // public key
     if (jsonHasProperties(json, "x", "y")) {
-      final BigInteger x = new BigInteger(1, json.getBinary("x"));
-      final BigInteger y = new BigInteger(1, json.getBinary("y"));
+      final BigInteger x = new BigInteger(1, base64UrlDecode(json.getString("x")));
+      final BigInteger y = new BigInteger(1, base64UrlDecode(json.getString("y")));
       publicKey = KeyFactory.getInstance("EC").generatePublic(new ECPublicKeySpec(new ECPoint(x, y), parameters.getParameterSpec(ECParameterSpec.class)));
     }
 
     // private key
     if (jsonHasProperties(json, "d")) {
-      final BigInteger d = new BigInteger(1, json.getBinary("d"));
+      final BigInteger d = new BigInteger(1, base64UrlDecode(json.getString("d")));
       privateKey = KeyFactory.getInstance("EC").generatePrivate(new ECPrivateKeySpec(d, parameters.getParameterSpec(ECParameterSpec.class)));
     }
   }
@@ -496,7 +498,7 @@ public final class JWK {
   private void createOKP(JsonObject json) throws NoSuchAlgorithmException, InvalidKeySpecException {
     // public key
     if (jsonHasProperties(json, "x")) {
-      final byte[] key = json.getBinary("x");
+      final byte[] key = base64UrlDecode(json.getString("x"));
       final byte bitStringTag = (byte) 0x3;
 
       //  SPKI ::= SEQUENCE {
@@ -521,7 +523,7 @@ public final class JWK {
 
     // private key
     if (jsonHasProperties(json, "d")) {
-      final byte[] key = json.getBinary("d");
+      final byte[] key = base64UrlDecode(json.getString("d"));
       final byte octetStringTag = (byte) 0x4;
 
       byte[] asnKey = Buffer.buffer()
@@ -557,7 +559,7 @@ public final class JWK {
 
   private void createOCT(String alias, JsonObject json) throws NoSuchAlgorithmException, InvalidKeyException {
     mac = Mac.getInstance(alias);
-    mac.init(new SecretKeySpec(json.getBinary("k"), alias));
+    mac.init(new SecretKeySpec(base64UrlDecode(json.getString("k")), alias));
   }
 
   public String getAlgorithm() {

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWT.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWT.java
@@ -282,7 +282,7 @@ public final class JWT {
         // post value.
         synchronized (this) {
           nonceDigest.reset();
-          header.put("nonce", nonceDigest.digest(header.getString("nonce").getBytes(StandardCharsets.UTF_8)));
+          header.put("nonce", base64UrlEncode(nonceDigest.digest(header.getString("nonce").getBytes(StandardCharsets.UTF_8))));
           headerSeg = base64UrlEncode(header.encode().getBytes(StandardCharsets.UTF_8));
         }
       }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWT.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWT.java
@@ -32,8 +32,7 @@ import java.security.cert.X509Certificate;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
-import static io.vertx.ext.auth.impl.Codec.base64UrlEncode;
+import static io.vertx.ext.auth.impl.Codec.*;
 
 /**
  * JWT and JWS implementation draft-ietf-oauth-json-web-token-32.
@@ -48,8 +47,6 @@ public final class JWT {
   private static final Random RND = new Random();
 
   private static final Charset UTF8 = StandardCharsets.UTF_8;
-
-  private static final Base64.Decoder decoder = Base64.getDecoder();
 
   private boolean allowEmbeddedKey = false;
   private X509Certificate rootCA;
@@ -113,7 +110,7 @@ public final class JWT {
    * @return fluent self.
    */
   public JWT embeddedKeyRootCA(String rootCA) throws CertificateException {
-    this.rootCA = JWS.parseX5c(decoder.decode(rootCA.getBytes(UTF8)));
+    this.rootCA = JWS.parseX5c(base64Decode(rootCA));
     this.allowEmbeddedKey = true;
     return this;
   }
@@ -245,7 +242,7 @@ public final class JWT {
           // states:
           // Each string in the array is a base64-encoded (Section 4 of [RFC4648] -- not base64url-encoded) DER
           // [ITU.X690.2008] PKIX certificate value.
-          certChain.add(JWS.parseX5c(decoder.decode(chain.getString(i).getBytes(UTF8))));
+          certChain.add(JWS.parseX5c(base64Decode(chain.getString(i))));
         }
 
         if (rootCA != null) {

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/it/JWKLegacyBase64Test.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/it/JWKLegacyBase64Test.java
@@ -1,0 +1,11 @@
+package io.vertx.ext.auth.it;
+
+import io.vertx.ext.auth.JWKTest;
+
+public class JWKLegacyBase64Test extends JWKTest {
+
+  static {
+    System.setProperty("vertx.json.base64", "legacy");
+  }
+
+}

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCUserUtilImpl.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCUserUtilImpl.java
@@ -24,7 +24,8 @@ import io.vertx.ext.auth.jdbc.JDBCUserUtil;
 import io.vertx.ext.jdbc.JDBCClient;
 
 import java.security.SecureRandom;
-import java.util.*;
+
+import static io.vertx.ext.auth.impl.Codec.base64Encode;
 
 public class JDBCUserUtilImpl implements JDBCUserUtil {
 
@@ -65,7 +66,7 @@ public class JDBCUserUtilImpl implements JDBCUserUtil {
       username,
       strategy.hash("pbkdf2",
         null,
-        Base64.getMimeEncoder().encodeToString(salt),
+        base64Encode(salt),
         password),
       resultHandler
     );

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUserUtilImpl.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoUserUtilImpl.java
@@ -26,9 +26,10 @@ import io.vertx.ext.auth.mongo.MongoUserUtil;
 import io.vertx.ext.mongo.MongoClient;
 
 import java.security.SecureRandom;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+
+import static io.vertx.ext.auth.impl.Codec.base64Encode;
 
 public class MongoUserUtilImpl implements MongoUserUtil {
 
@@ -63,7 +64,7 @@ public class MongoUserUtilImpl implements MongoUserUtil {
       username,
       strategy.hash("pbkdf2",
         null,
-        Base64.getMimeEncoder().encodeToString(salt),
+        base64Encode(salt),
         password),
       resultHandler
     );

--- a/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
+++ b/vertx-auth-oauth2/src/main/java/examples/AuthOAuth2Examples.java
@@ -361,7 +361,7 @@ public class AuthOAuth2Examples {
       new OAuth2Options()
         .setClientId("clientId")
         .setClientSecret("clientSecret")
-        .setSite("http://keycloakhost:keycloakport/auth/realms/{realm}")
+        .setSite("https://keycloakhost:keycloakport/auth/realms/{realm}")
         .setTenant("your-realm"))
       .onSuccess(oauth2 -> {
         // ...
@@ -418,7 +418,7 @@ public class AuthOAuth2Examples {
       new OAuth2Options()
         .setClientId("clientId")
         .setTenant("your_realm")
-        .setSite("http://server:port/auth/realms/{tenant}"))
+        .setSite("https://server:port/auth/realms/{tenant}"))
       .onSuccess(oauth2 -> {
         // the setup call succeeded.
         // at this moment your auth is ready to use

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
@@ -33,11 +33,12 @@ import io.vertx.ext.auth.oauth2.OAuth2Options;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static io.vertx.ext.auth.impl.Codec.base64Encode;
 
 /**
  * @author Paulo Lopes
@@ -178,7 +179,7 @@ public class OAuth2API {
 
     if (confidentialClient) {
       String basic = config.getClientId() + ":" + config.getClientSecret();
-      headers.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes(StandardCharsets.UTF_8)));
+      headers.put("Authorization", "Basic " + base64Encode(basic.getBytes(StandardCharsets.UTF_8)));
     }
 
     // Enable the system to send authorization params in the body (for example github does not require to be in the header)
@@ -270,7 +271,7 @@ public class OAuth2API {
 
     if (confidentialClient) {
       String basic = config.getClientId() + ":" + config.getClientSecret();
-      headers.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes(StandardCharsets.UTF_8)));
+      headers.put("Authorization", "Basic " + base64Encode(basic.getBytes(StandardCharsets.UTF_8)));
     }
 
     final JsonObject form = new JsonObject()
@@ -352,7 +353,7 @@ public class OAuth2API {
 
     if (confidentialClient) {
       String basic = config.getClientId() + ":" + config.getClientSecret();
-      headers.put("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes(StandardCharsets.UTF_8)));
+      headers.put("Authorization", "Basic " + base64Encode(basic.getBytes(StandardCharsets.UTF_8)));
     }
 
     final JsonObject form = new JsonObject();

--- a/vertx-auth-sql-client/src/main/java/io/vertx/ext/auth/sqlclient/impl/SqlUserUtilImpl.java
+++ b/vertx-auth-sql-client/src/main/java/io/vertx/ext/auth/sqlclient/impl/SqlUserUtilImpl.java
@@ -24,7 +24,8 @@ import io.vertx.sqlclient.SqlClient;
 import io.vertx.sqlclient.Tuple;
 
 import java.security.SecureRandom;
-import java.util.Base64;
+
+import static io.vertx.ext.auth.impl.Codec.base64Encode;
 
 public class SqlUserUtilImpl implements SqlUserUtil {
 
@@ -65,7 +66,7 @@ public class SqlUserUtilImpl implements SqlUserUtil {
       username,
       strategy.hash("pbkdf2",
         null,
-        Base64.getEncoder().encodeToString(salt),
+        base64Encode(salt),
         password),
       resultHandler
     );

--- a/vertx-auth-webauthn/pom.xml
+++ b/vertx-auth-webauthn/pom.xml
@@ -79,7 +79,7 @@
       <id>IT</id>
       <activation>
         <property>
-          <name>env.TRAVIS</name>
+          <name>env.CI</name>
           <value>true</value>
         </property>
       </activation>

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/WebAuthnOptions.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/WebAuthnOptions.java
@@ -43,7 +43,7 @@ public class WebAuthnOptions {
   /* Android Keystore Root is not published anywhere.
    * This certificate was extracted from one of the attestations
    * The last certificate in x5c must match this certificate
-   * This needs to be checked to ensure that malicious party wont generate fake attestations
+   * This needs to be checked to ensure that malicious party won't generate fake attestations
    */
   private static final String ANDROID_KEYSTORE_ROOT =
     "MIICizCCAjKgAwIBAgIJAKIFntEOQ1tXMAoGCCqGSM49BAMCMIGYMQswCQYDVQQG" +
@@ -132,7 +132,7 @@ public class WebAuthnOptions {
    *
    * Valid until 18 March 2029
    */
-  final String FIDO_MDS3_ROOT_CERTIFICATE =
+  private static final String FIDO_MDS3_ROOT_CERTIFICATE =
     "MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G" +
       "A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp" +
       "Z24xEzARBgNVBAMTCkdsb2JhbFNpZ24wHhcNMDkwMzE4MTAwMDAwWhcNMjkwMzE4" +

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/WebAuthnImpl.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/WebAuthnImpl.java
@@ -87,10 +87,10 @@ public class WebAuthnImpl implements WebAuthn {
     }
   }
 
-  private byte[] randomBase64URLBuffer(int length) {
+  private String randomBase64URLBuffer(int length) {
     final byte[] buff = new byte[length];
     random.nextBytes(buff);
-    return buff;
+    return base64UrlEncode(buff);
   }
 
   private void putOpt(JsonObject json, String key, Object value) {
@@ -133,11 +133,11 @@ public class WebAuthnImpl implements WebAuthn {
     }
   }
 
-  private static Buffer UUIDtoBuffer(UUID uuid) {
+  private static String uUIDtoBase64Url(UUID uuid) {
     Buffer buffer = Buffer.buffer(16);
     buffer.setLong(0, uuid.getMostSignificantBits());
     buffer.setLong(8, uuid.getLeastSignificantBits());
-    return buffer;
+    return base64UrlEncode(buffer.getBytes());
   }
 
   @Override
@@ -178,7 +178,7 @@ public class WebAuthnImpl implements WebAuthn {
         putOpt(json.getJsonObject("rp"), "icon", options.getRelyingParty().getIcon());
 
         // put non null values for User
-        putOpt(json.getJsonObject("user"), "id", UUIDtoBuffer(UUID.randomUUID()));
+        putOpt(json.getJsonObject("user"), "id", uUIDtoBase64Url(UUID.randomUUID()));
         putOpt(json.getJsonObject("user"), "name", user.getString("name"));
         putOpt(json.getJsonObject("user"), "displayName", user.getString("displayName"));
         putOpt(json.getJsonObject("user"), "icon", user.getString("icon"));

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/AndroidKeyAttestation.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/AndroidKeyAttestation.java
@@ -32,6 +32,7 @@ import java.security.cert.*;
 import java.util.Collections;
 import java.util.List;
 
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
 import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.*;
 import static io.vertx.ext.auth.impl.asn.ASN1.*;
 
@@ -85,7 +86,7 @@ public class AndroidKeyAttestation implements Attestation {
       // 2. Verify signature sig over the signatureBase using
       //    public key extracted from leaf certificate in x5c
       JsonObject attStmt = attestation.getJsonObject("attStmt");
-      byte[] signature = attStmt.getBinary("sig");
+      byte[] signature = base64UrlDecode(attStmt.getString("sig"));
       List<X509Certificate> certChain = parseX5c(attStmt.getJsonArray("x5c"));
       if (certChain.size() == 0) {
         throw new AttestationException("Invalid certificate chain");
@@ -161,7 +162,7 @@ public class AndroidKeyAttestation implements Attestation {
         if (rootCertificate == null) {
           throw new AttestationException("Root certificate is invalid!");
         }
-        if (!MessageDigest.isEqual(rootCertificate.getEncoded(), x5c.getBinary(x5c.size() - 1))) {
+        if (!MessageDigest.isEqual(rootCertificate.getEncoded(), base64UrlDecode(x5c.getString(x5c.size() - 1)))) {
           throw new AttestationException("Root certificate is invalid!");
         }
       }

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/AndroidSafetynetAttestation.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/AndroidSafetynetAttestation.java
@@ -34,9 +34,9 @@ import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 
+import static io.vertx.ext.auth.impl.Codec.base64Decode;
 import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
 import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.hash;
 import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.verifySignature;
@@ -51,9 +51,6 @@ import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.verifySign
  * @author <a href="mailto:pmlopes@gmail.com>Paulo Lopes</a>
  */
 public class AndroidSafetynetAttestation implements Attestation {
-
-  // codecs
-  private static final Base64.Decoder b64dec = Base64.getDecoder();
 
   @Override
   public String fmt() {
@@ -89,7 +86,7 @@ public class AndroidSafetynetAttestation implements Attestation {
         .appendBytes(clientDataHash);
       // 3. Hash nonceBase using SHA256 to create nonceBuffer.
       // 4. Check that “nonce” is set to expectedNonce
-      if (!MessageDigest.isEqual(hash("SHA-256", nonceBase.getBytes()), b64dec.decode(token.getJsonObject("payload").getString("nonce")))) {
+      if (!MessageDigest.isEqual(hash("SHA-256", nonceBase.getBytes()), base64Decode(token.getJsonObject("payload").getString("nonce")))) {
         throw new AttestationException("JWS nonce does not contains expected nonce!");
       }
       // 5. Check that “ctsProfileMatch” is set to true. If its not set to true, that means that device has been rooted
@@ -113,7 +110,7 @@ public class AndroidSafetynetAttestation implements Attestation {
       List<X509Certificate> certChain = new ArrayList<>();
 
       for (int i = 0; i < x5c.size(); i++) {
-        final byte[] bytes = b64dec.decode(x5c.getString(i));
+        final byte[] bytes = base64Decode(x5c.getString(i));
         certChain.add(JWS.parseX5c(bytes));
         // patch the x5c data to be base64url
         x5c.set(i, bytes);

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/AndroidSafetynetAttestation.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/AndroidSafetynetAttestation.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
 import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.hash;
 import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.verifySignature;
 
@@ -77,7 +78,7 @@ public class AndroidSafetynetAttestation implements Attestation {
         throw new AttestationException("Missing {ver} in attStmt");
       }
       // response is a JWT
-      JsonObject token = JWT.parse(attStmt.getBinary("response"));
+      JsonObject token = JWT.parse(base64UrlDecode(attStmt.getString("response")));
 
       // verify the payload:
       // 1. Hash clientDataJSON using SHA256, to create clientDataHash
@@ -138,7 +139,7 @@ public class AndroidSafetynetAttestation implements Attestation {
       verifySignature(
         PublicKeyCredential.valueOf(token.getJsonObject("header").getString("alg")),
         certChain.get(0),
-        token.getBinary("signature"),
+        base64UrlDecode(token.getString("signature")),
         token.getString("signatureBase").getBytes(StandardCharsets.UTF_8));
 
       return new AttestationCertificates()

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/Attestation.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/Attestation.java
@@ -30,6 +30,8 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
+
 public interface Attestation {
 
   /**
@@ -94,7 +96,7 @@ public interface Attestation {
     }
 
     for (int i = 0; i < x5c.size(); i++) {
-      certChain.add(JWS.parseX5c(x5c.getBinary(i)));
+      certChain.add(JWS.parseX5c(base64UrlDecode(x5c.getString(i))));
     }
 
     return certChain;

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/FidoU2fAttestation.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/FidoU2fAttestation.java
@@ -35,6 +35,7 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Map;
 
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
 import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.*;
 
 /**
@@ -98,7 +99,7 @@ public class FidoU2fAttestation implements Attestation {
       verifySignature(
         PublicKeyCredential.ES256,
         certChain.get(0),
-        attStmt.getBinary("sig"),
+        base64UrlDecode(attStmt.getString("sig")),
         signatureBase.getBytes());
 
       return new AttestationCertificates()
@@ -138,8 +139,8 @@ public class FidoU2fAttestation implements Attestation {
 
       return Buffer.buffer()
         .appendByte((byte) 0x04)
-        .appendBytes(key.getBinary("-2"))
-        .appendBytes(key.getBinary("-3"))
+        .appendBytes(base64UrlDecode(key.getString("-2")))
+        .appendBytes(base64UrlDecode(key.getString("-3")))
         .getBytes();
     } catch (IOException e) {
       throw new DecodeException(e.getMessage());

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/PackedAttestation.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/PackedAttestation.java
@@ -34,6 +34,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.*;
 
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
 import static io.vertx.ext.auth.impl.asn.ASN1.OCTET_STRING;
 import static io.vertx.ext.auth.impl.asn.ASN1.parseASN1;
 import static io.vertx.ext.auth.webauthn.impl.attestation.Attestation.*;
@@ -64,7 +65,7 @@ public class PackedAttestation implements Attestation {
 
       // Check attStmt and it contains “x5c” then its a FULL attestation.
       JsonObject attStmt = attestation.getJsonObject("attStmt");
-      byte[] signature = attStmt.getBinary("sig");
+      byte[] signature = base64UrlDecode(attStmt.getString("sig"));
 
       if (attStmt.containsKey("x5c")) {
         // FULL basically means that it’s an attestation that chains to the manufacturer.

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/TPMAttestation.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/TPMAttestation.java
@@ -29,6 +29,7 @@ import io.vertx.ext.auth.webauthn.impl.attestation.tpm.CertInfo;
 import io.vertx.ext.auth.webauthn.impl.attestation.tpm.PubArea;
 import io.vertx.ext.auth.webauthn.impl.metadata.MetaDataException;
 
+import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -324,7 +325,7 @@ public class TPMAttestation implements Attestation {
         ASN1.ASN val = el.object(1, ASN1.UTF8_STRING);
 
         if (MessageDigest.isEqual(oid.binary(0), new byte[]{0x67, (byte) 0x81, 0x05, 0x02, 0x01})) {
-          if (!TPM_MANUFACTURERS.contains(new String(val.binary(0)))) {
+          if (!TPM_MANUFACTURERS.contains(new String(val.binary(0), StandardCharsets.UTF_8))) {
             throw new AttestationException("Unknown Manufacturer id");
           }
         }

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/metadata/MetaDataEntry.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/metadata/MetaDataEntry.java
@@ -33,6 +33,8 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
+import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
+
 public class MetaDataEntry implements Shareable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetaDataEntry.class);
@@ -107,7 +109,7 @@ public class MetaDataEntry implements Shareable {
       // verify the hash
       MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
       byte[] digest = sha256.digest(rawStatement);
-      if (MessageDigest.isEqual(digest, entry.getBinary("hash"))) {
+      if (MessageDigest.isEqual(digest, base64UrlDecode(entry.getString("hash")))) {
         this.error = null;
       } else {
         this.error = "MDS entry hash did not match corresponding hash in MDS TOC";
@@ -145,5 +147,9 @@ public class MetaDataEntry implements Shareable {
 
   JsonObject statement() {
     return statement;
+  }
+
+  int version() {
+    return version;
   }
 }

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/metadata/MetaDataEntry.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/metadata/MetaDataEntry.java
@@ -29,17 +29,16 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 
+import static io.vertx.ext.auth.impl.Codec.base64Decode;
 import static io.vertx.ext.auth.impl.Codec.base64UrlDecode;
 
 public class MetaDataEntry implements Shareable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetaDataEntry.class);
 
-  private static final Base64.Decoder BASE64DEC = Base64.getDecoder();
   // https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html
   private static final List<String> INVALID_STATUS = Arrays
     .asList(
@@ -92,7 +91,7 @@ public class MetaDataEntry implements Shareable {
     }
 
     this.entry = tocEntry;
-    this.statement = new JsonObject(Buffer.buffer(BASE64DEC.decode(rawStatement)));
+    this.statement = new JsonObject(Buffer.buffer(base64Decode(rawStatement)));
     this.version = statement.getInteger("schema", 2);
 
     // convert status report effective date to a Instant

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/metadata/MetaDataServiceImpl.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/metadata/MetaDataServiceImpl.java
@@ -20,7 +20,6 @@ import io.vertx.ext.auth.webauthn.MetaDataService;
 import io.vertx.ext.auth.webauthn.WebAuthnOptions;
 import io.vertx.ext.auth.webauthn.impl.attestation.AttestationException;
 
-import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.cert.*;
 import java.util.*;
@@ -28,10 +27,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.vertx.core.json.impl.JsonUtil.BASE64_DECODER;
+import static io.vertx.ext.auth.impl.Codec.base64Decode;
 
 public class MetaDataServiceImpl implements MetaDataService {
 
-  private static final Base64.Decoder BASE64DEC = Base64.getDecoder();
   private static final Logger LOG = LoggerFactory.getLogger(MetaDataServiceImpl.class);
 
   private final VertxInternal vertx;
@@ -80,7 +79,7 @@ public class MetaDataServiceImpl implements MetaDataService {
             // states:
             // Each string in the array is a base64-encoded (Section 4 of [RFC4648] -- not base64url-encoded) DER
             // [ITU.X690.2008] PKIX certificate value.
-            certChain.add(JWS.parseX5c(BASE64DEC.decode(chain.getString(i).getBytes(StandardCharsets.UTF_8))));
+            certChain.add(JWS.parseX5c(base64Decode(chain.getString(i))));
           }
           // add the root certificate
           certChain.add(options.getRootCertificate("mds"));


### PR DESCRIPTION
Motivation:

auth modules were relying on the vertx-core default base64 encoding, this is wrong when legacy mode is active. This PR ensures that all base64 operations are explicit.

Fixes #510 