### PR TITLE
Fix #513: do not require a clientId for Resource Owner Password, as w…

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
@@ -20,6 +20,8 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.JWTOptions;
@@ -37,6 +39,8 @@ import java.util.regex.Pattern;
  */
 @DataObject(generateConverter = true)
 public class OAuth2Options {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OAuth2Options.class);
 
   // Defaults
   private static final OAuth2FlowType FLOW = OAuth2FlowType.AUTH_CODE;
@@ -611,11 +615,22 @@ public class OAuth2Options {
       case AUTH_CODE:
       case AUTH_JWT:
       case AAD_OBO:
-      case PASSWORD:
         if (clientAssertion == null && clientAssertionType == null) {
           // not using client assertions
           if (clientId == null) {
             throw new IllegalStateException("Configuration missing. You need to specify [clientId]");
+          }
+        } else {
+          if (clientAssertion == null || clientAssertionType == null) {
+            throw new IllegalStateException("Configuration missing. You need to specify [clientAssertion] AND [clientAssertionType]");
+          }
+        }
+        break;
+      case PASSWORD:
+        if (clientAssertion == null && clientAssertionType == null) {
+          // not using client assertions
+          if (clientId == null) {
+            LOG.debug("If you are using Client Oauth2 Resource Owner flow. You need to specify [clientId]");
           }
         } else {
           if (clientAssertion == null || clientAssertionType == null) {

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
@@ -150,9 +150,14 @@ public class OAuth2API {
     if (clientId != null) {
       query.put("client_id", clientId);
     } else {
-      query
-        .put("client_assertion_type", config.getClientAssertionType())
-        .put("client_assertion", config.getClientAssertion());
+      if (config.getClientAssertionType() != null) {
+        query
+          .put("client_assertion_type", config.getClientAssertionType());
+      }
+      if (config.getClientAssertion() != null) {
+        query
+          .put("client_assertion", config.getClientAssertion());
+      }
     }
 
     final String path = config.getAuthorizationPath();
@@ -195,9 +200,14 @@ public class OAuth2API {
       if (clientId != null) {
         form.put("client_id", clientId);
       } else {
-        form
-          .put("client_assertion_type", config.getClientAssertionType())
-          .put("client_assertion", config.getClientAssertion());
+        if (config.getClientAssertionType() != null) {
+          form
+            .put("client_assertion_type", config.getClientAssertionType());
+        }
+        if (config.getClientAssertion() != null) {
+          form
+            .put("client_assertion", config.getClientAssertion());
+        }
       }
     }
 

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ResourceOwnerPasswordTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2ResourceOwnerPasswordTest.java
@@ -1,0 +1,95 @@
+package io.vertx.ext.auth.test.oauth2;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.impl.http.SimpleHttpClient;
+import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.oauth2.OAuth2FlowType;
+import io.vertx.ext.auth.oauth2.OAuth2Options;
+import io.vertx.test.core.VertxTestBase;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.CountDownLatch;
+
+public class OAuth2ResourceOwnerPasswordTest extends VertxTestBase {
+
+  private static final JsonObject fixture = new JsonObject(
+    "{" +
+      "  \"access_token\": \"4adc339e0\"," +
+      "  \"refresh_token\": \"ec1a59d298\"," +
+      "  \"token_type\": \"bearer\"," +
+      "  \"expires_in\": 7200" +
+      "}");
+
+  private static final JsonObject tokenConfig = new JsonObject()
+    .put("username", "alice")
+    .put("password", "secret");
+
+  private static final JsonObject oauthConfig = new JsonObject()
+    .put("password", "secret")
+    .put("grant_type", "password")
+    .put("username", "alice");
+
+  protected OAuth2Auth oauth2;
+  private HttpServer server;
+  private JsonObject config;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    oauth2 = OAuth2Auth.create(vertx, new OAuth2Options()
+      .setFlow(OAuth2FlowType.PASSWORD)
+      .setSite("http://localhost:8080"));
+
+    final CountDownLatch latch = new CountDownLatch(1);
+
+    server = vertx.createHttpServer().requestHandler(req -> {
+      if (req.method() == HttpMethod.POST && "/oauth/token".equals(req.path())) {
+        assertNull(req.getHeader("Authorization"));
+        req.setExpectMultipart(true).bodyHandler(buffer -> {
+          try {
+            assertEquals(config, SimpleHttpClient.queryToJson(buffer));
+          } catch (UnsupportedEncodingException e) {
+            fail(e);
+          }
+          req.response().putHeader("Content-Type", "application/json").end(fixture.encode());
+        });
+      } else {
+        req.response().setStatusCode(400).end();
+      }
+    }).listen(8080, ready -> {
+      if (ready.failed()) {
+        throw new RuntimeException(ready.cause());
+      }
+      // ready
+      latch.countDown();
+    });
+
+    latch.await();
+  }
+
+  @Override
+  public void tearDown() throws Exception {
+    server.close();
+    super.tearDown();
+  }
+
+  @Test
+  public void getToken() {
+    config = oauthConfig;
+    oauth2.authenticate(tokenConfig, res -> {
+      if (res.failed()) {
+        fail(res.cause().getMessage());
+      } else {
+        User token = res.result();
+        assertNotNull(token);
+        assertNotNull(token.principal());
+        testComplete();
+      }
+    });
+    await();
+  }
+}


### PR DESCRIPTION
…ebclient can use this module too, which means Client and Resource Owner can be 2 different entities

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Fix #513 