### PR TITLE
Documentation typo for TOTP Authentication

### DIFF
--- a/vertx-auth-otp/src/main/asciidoc/index.adoc
+++ b/vertx-auth-otp/src/main/asciidoc/index.adoc
@@ -46,7 +46,7 @@ Note that when authenticating using this implementation, it assumes `identifier`
 
 == TOTP Authentication
 
-To create an instance of the Hotp auth provider, use {@link io.vertx.ext.auth.otp.totp.TotpAuth#create(io.vertx.ext.auth.otp.totp.TotpAuthOptions)} as follows
+To create an instance of the Totp auth provider, use {@link io.vertx.ext.auth.otp.totp.TotpAuth#create(io.vertx.ext.auth.otp.totp.TotpAuthOptions)} as follows
 
 === TOTP Configuration
 


### PR DESCRIPTION
fix document typo

fix `Hotp auth provider` to `Totp auth provider` in **TOTP Authentication**

Motivation:

Found a typo when I tried to translate document to Chinese