### PR TITLE
#521 Support a collections of roles in the MongoDB AuthorizationProvider

### DIFF
--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoAuthorization.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoAuthorization.java
@@ -30,7 +30,7 @@ import io.vertx.ext.mongo.MongoClient;
 public interface MongoAuthorization extends AuthorizationProvider {
 
   /**
-   * The default name of the collection to be used
+   * The default name of the collection to be used to store user permissions and roles
    */
   String DEFAULT_COLLECTION_NAME = "authorizations";
 
@@ -50,6 +50,27 @@ public interface MongoAuthorization extends AuthorizationProvider {
    * saved as JsonArray
    */
   String DEFAULT_PERMISSION_FIELD = "permissions";
+
+  /**
+   * The default value of enablement of the behavior consisting in reading role definitions from another collection to get permissions attached to roles.
+   */
+  boolean DEFAULT_READ_ROLE_PERMISSIONS = false;
+
+  /**
+   * The default name of the collection to be used to store role definitions
+   */
+  String DEFAULT_ROLES_COLLECTION_NAME = "roles";
+
+  /**
+   * The default name of the property for the role name, like it is stored in mongodb
+   */
+  String DEFAULT_ROLENAME_FIELD = "rolename";
+
+  /**
+   * The default name of the property for role permissions, like it is stored in mongodb. Permissions are expected to be
+   * saved as JsonArray
+   */
+  String DEFAULT_ROLE_PERMISSION_FIELD = "permissions";
 
   /**
    * Creates an instance of MongoAuthorization by using the given {@link MongoClient} and configuration object.

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoAuthorizationOptions.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoAuthorizationOptions.java
@@ -31,12 +31,20 @@ public class MongoAuthorizationOptions {
   private String usernameField;
   private String roleField;
   private String permissionField;
+  private String roleCollectionName;
+  private String roleNameField;
+  private String rolePermissionField;
+  private boolean readRolePermissions;
 
   public MongoAuthorizationOptions() {
     collectionName = MongoAuthorization.DEFAULT_COLLECTION_NAME;
     usernameField = MongoAuthorization.DEFAULT_USERNAME_FIELD;
     roleField = MongoAuthorization.DEFAULT_ROLE_FIELD;
     permissionField = MongoAuthorization.DEFAULT_PERMISSION_FIELD;
+    roleCollectionName = MongoAuthorization.DEFAULT_ROLES_COLLECTION_NAME;
+    roleNameField = MongoAuthorization.DEFAULT_ROLENAME_FIELD;
+    rolePermissionField = MongoAuthorization.DEFAULT_ROLE_PERMISSION_FIELD;
+    readRolePermissions = MongoAuthorization.DEFAULT_READ_ROLE_PERMISSIONS;
   }
 
   public MongoAuthorizationOptions(JsonObject json) {
@@ -49,7 +57,13 @@ public class MongoAuthorizationOptions {
   }
 
   /**
-   * The property name to be used to set the name of the collection inside the config.
+   * Set the name of the MongoDB collection containing user authorizations.
+   * Per default configuration, that collection is called <code>user</code> and is expected to contain objects having the following fields:
+   * <ul>
+   *     <li><code>username</code>: field name can be overridden with {@link #setUsernameField(String) setUsernameField} </li>
+   *     <li><code>permissions</code>: field name can be overridden with {@link #setPermissionField(String) setPermissionField} </li>
+   *     <li><code>roles</code>: field name can be overridden with {@link #setRoleField(String) setPermissionField} </li>
+   * </ul>
    *
    * @param collectionName the collection name
    * @return a reference to this, so the API can be used fluently
@@ -59,12 +73,33 @@ public class MongoAuthorizationOptions {
     return this;
   }
 
+  public String getRoleCollectionName() {
+    return roleCollectionName;
+  }
+
+  /**
+   * Set the name of the MongoDB collection containing role definitions.
+   * Per default configuration, that collection is called <code>roles</code> and is expected to contain objects having the following properties:
+   * <ul>
+   *     <li><code>rolename</code>: can be overridden with {@link #setRoleNameField(String) setRoleNameField} </li>
+   *     <li><code>permissions</code>: can be overridden with {@link #setRolePermissionField(String) setRolePermissionField} </li>
+   * </ul>
+   *
+   * @param roleCollectionName the collection name
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MongoAuthorizationOptions setRoleCollectionName(String roleCollectionName) {
+    this.roleCollectionName = roleCollectionName;
+    return this;
+  }
+
   public String getUsernameField() {
     return usernameField;
   }
 
   /**
-   * The property name to be used to set the name of the field, where the username is stored inside.
+   * Set the name of field containing the username in the collection of user authorizations.
+   * The default value is <code>username</code>.
    *
    * @param usernameField the username field
    * @return a reference to this, so the API can be used fluently
@@ -79,7 +114,8 @@ public class MongoAuthorizationOptions {
   }
 
   /**
-   * The property name to be used to set the name of the field, where the roles are stored inside.
+   * Set the name of field containing user roles in the collection of user authorizations.
+   * The default value is <code>roles</code>.
    *
    * @param roleField the role field
    * @return a reference to this, so the API can be used fluently
@@ -94,7 +130,8 @@ public class MongoAuthorizationOptions {
   }
 
   /**
-   * The property name to be used to set the name of the field, where the permissions are stored inside.
+   * Set the name of field containing user permissions in the collection of user authorizations.
+   * The default value is <code>permissions</code>.
    *
    * @param permissionField the permission field
    * @return a reference to this, so the API can be used fluently
@@ -103,4 +140,53 @@ public class MongoAuthorizationOptions {
     this.permissionField = permissionField;
     return this;
   }
+
+  public String getRoleNameField() {
+    return roleNameField;
+  }
+
+  /**
+   * Set the name of field containing the name of the role in the collection of role definitions.
+   * The default value is <code>rolename</code>.
+   *
+   * @param roleNameField the role name field
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MongoAuthorizationOptions setRoleNameField(String roleNameField) {
+    this.roleNameField = roleNameField;
+    return this;
+  }
+
+  public String getRolePermissionField() {
+    return rolePermissionField;
+  }
+
+  /**
+   * Set the name of field containing role permissions in the collection of role definitions.
+   * The default value is <code>permissions</code>.
+   *
+   * @param rolePermissionField the permission field
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MongoAuthorizationOptions setRolePermissionField(String rolePermissionField) {
+    this.rolePermissionField = rolePermissionField;
+    return this;
+  }
+
+  public boolean isReadRolePermissions() {
+    return readRolePermissions;
+  }
+
+  /**
+   * Enable or disable the behavior consisting in reading role definitions from another collection to get permissions attached to roles.
+   * The default value is <code>false</code>.
+   *
+   * @param readRolePermissions true to enable, false to disable the behavior
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MongoAuthorizationOptions setReadRolePermissions(boolean readRolePermissions) {
+    this.readRolePermissions = readRolePermissions;
+    return this;
+  }
+
 }

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoAuthorizationOptions.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/MongoAuthorizationOptions.java
@@ -58,7 +58,7 @@ public class MongoAuthorizationOptions {
 
   /**
    * Set the name of the MongoDB collection containing user authorizations.
-   * Per default configuration, that collection is called <code>user</code> and is expected to contain objects having the following fields:
+   * Per default configuration, that collection is called <code>authorizations</code> and is expected to contain objects having the following fields:
    * <ul>
    *     <li><code>username</code>: field name can be overridden with {@link #setUsernameField(String) setUsernameField} </li>
    *     <li><code>permissions</code>: field name can be overridden with {@link #setPermissionField(String) setPermissionField} </li>

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthorizationImpl.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthorizationImpl.java
@@ -106,7 +106,6 @@ public class MongoAuthorizationImpl implements MongoAuthorization {
         handler.handle(Future.failedFuture(res.cause()));
         return;
       }
-      user.authorizations().clear(providerId);
       for (JsonObject jsonObject : res.result()) {
         JsonArray roles = jsonObject.getJsonArray(options.getRoleField());
         if (roles != null) {

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthorizationImpl.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthorizationImpl.java
@@ -24,12 +24,14 @@ import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authorization.Authorization;
 import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
 import io.vertx.ext.auth.authorization.RoleBasedAuthorization;
 import io.vertx.ext.auth.mongo.*;
+import io.vertx.ext.mongo.FindOptions;
 import io.vertx.ext.mongo.MongoClient;
 
-import java.util.Objects;
+import java.util.*;
 
 /**
  * An implementation of {@link MongoAuthorization}
@@ -41,11 +43,12 @@ public class MongoAuthorizationImpl implements MongoAuthorization {
   private final MongoClient mongoClient;
   private final String providerId;
   private final MongoAuthorizationOptions options;
+  private final JsonArray lookupRolePermissionsPipeline;
 
   /**
    * Creates a new instance
    * @param providerId
-    *          the provider ID to differentiate from others
+   *          the provider ID to differentiate from others
    * @param mongoClient
    *          the {@link MongoClient} to be used
    * @param options
@@ -55,6 +58,8 @@ public class MongoAuthorizationImpl implements MongoAuthorization {
     this.providerId = Objects.requireNonNull(providerId);
     this.mongoClient = mongoClient;
     this.options = options;
+    // precompute the part of the pipeline that never changes
+    this.lookupRolePermissionsPipeline = options.isReadRolePermissions() ? lookupRolePermissionsPipeline() : null;
   }
 
   /**
@@ -64,7 +69,28 @@ public class MongoAuthorizationImpl implements MongoAuthorization {
    * @return
    */
   protected JsonObject createQuery(String username) {
-    return new JsonObject().put(options.getUsernameField(), username);
+    if (!options.isReadRolePermissions()) {
+      return new JsonObject().put(options.getUsernameField(), username);
+    } else {
+      JsonArray pipeline = new JsonArray();
+      // match the user at the beginning of the pipeline
+      pipeline.add(new JsonObject()
+        .put("$match", new JsonObject()
+          .put(options.getUsernameField(), username)
+        )
+      );
+      // the rest of the pipeline does not change
+      for (int i=0 ; i<lookupRolePermissionsPipeline.size() ; i++) {
+        pipeline.add(lookupRolePermissionsPipeline.getJsonObject(i));
+      }
+      return new JsonObject()
+        .put("aggregate", options.getCollectionName())
+        .put("pipeline", pipeline)
+        // make sure the batch size is larger than the expected result size (= 1)
+        .put("cursor", new JsonObject()
+          .put("batchSize", 2)
+        );
+    }
   }
 
   @Override
@@ -75,30 +101,159 @@ public class MongoAuthorizationImpl implements MongoAuthorization {
   @Override
   public void getAuthorizations(User user, Handler<AsyncResult<Void>> handler) {
     JsonObject query = createQuery(user.principal().getString(options.getUsernameField()));
-    mongoClient.find(options.getCollectionName(), query, res -> {
-
+    Handler<AsyncResult<List<JsonObject>>> queryResultHandler = res -> {
       if (res.failed()) {
         handler.handle(Future.failedFuture(res.cause()));
         return;
       }
-
+      user.authorizations().clear(providerId);
       for (JsonObject jsonObject : res.result()) {
         JsonArray roles = jsonObject.getJsonArray(options.getRoleField());
-        if (roles!=null) {
-          for (int i=0; i<roles.size(); i++) {
+        if (roles != null) {
+          for (int i = 0; i < roles.size(); i++) {
             String role = roles.getString(i);
             user.authorizations().add(providerId, RoleBasedAuthorization.create(role));
           }
         }
         JsonArray permissions = jsonObject.getJsonArray(options.getPermissionField());
-        if (permissions!=null) {
-          for (int i=0; i<permissions.size(); i++) {
+        if (permissions != null) {
+          for (int i = 0; i < permissions.size(); i++) {
             String permission = permissions.getString(i);
-            user.authorizations().add(providerId, PermissionBasedAuthorization.create(permission));
+            Authorization authorization = PermissionBasedAuthorization.create(permission);
+            user.authorizations().add(providerId, authorization);
           }
         }
       }
       handler.handle(Future.succeededFuture());
-    });
+    };
+    if (!options.isReadRolePermissions()) {
+      FindOptions findOptions = new FindOptions()
+        .setLimit(1)
+        .setFields(
+          new JsonObject()
+            .put("_id", 0)
+            .put(options.getUsernameField(), 1)
+            .put(options.getPermissionField(), 1)
+            .put(options.getRoleField(), 1));
+      mongoClient.findWithOptions(options.getCollectionName(), query, findOptions, queryResultHandler);
+    } else {
+      mongoClient.runCommand("aggregate", query, res -> {
+        if (res.succeeded()) {
+          JsonArray batch = res.result().getJsonObject("cursor").getJsonArray("firstBatch");
+          List<JsonObject> usersList;
+          if (batch.isEmpty()) {
+            usersList = Collections.emptyList();
+          } else {
+            JsonObject result = batch.getJsonObject(0);
+            JsonArray users = result.getJsonArray("users");
+            usersList = new ArrayList<>(result.size());
+            for (int i=0; i<users.size() ; i++) {
+              usersList.add(users.getJsonObject(0));
+            }
+          }
+          queryResultHandler.handle(Future.succeededFuture(usersList));
+        } else {
+          queryResultHandler.handle(Future.failedFuture(res.cause()));
+        }
+      });
+    }
   }
+
+  private JsonArray lookupRolePermissionsPipeline() {
+    // the full pipeline looks like this:
+    // (not that this method does not create the first $match step that is dependent on the username)
+    /*
+        [{$match: {
+          "username": "tim"
+        }}, {$lookup: {
+          from: 'role',
+          localField: 'roles',
+          foreignField: 'rolename',
+          as: 'joinedRoles'
+        }}, {$project: {
+          _id: 0,
+          username: 1,
+          roles: 1,
+          "permissions": {
+            $reduce: {
+              input: "$joinedRoles.permissions",
+              initialValue: {
+                $cond: {
+                  if: {
+                    $isArray: ["$permissions"]
+                  },
+                  then: "$permissions",
+                  else: []
+                }
+              },
+              in: {
+                $setUnion: ["$$value", { $cond: { if: { $isArray: [ "$$this" ] }, then: "$$this", else: [] } }]
+              }
+            }
+          }
+        }}, {$group: {
+          _id: "username",
+          users: {
+            $push: "$$ROOT"
+          }
+        }}]
+    */
+    JsonArray result = new JsonArray();
+    // lookup role permissions from the role collections
+    result.add(new JsonObject()
+        .put("$lookup", new JsonObject()
+          .put("from", options.getRoleCollectionName())
+          .put("localField", options.getRoleField())
+          .put("foreignField", options.getRoleNameField())
+          .put("as", "joinedRoles")
+        )
+      )
+      // merge users permissions and all roles permissions into a new permissions array
+      .add(new JsonObject()
+        .put("$project", new JsonObject()
+          .put("_id", 0)
+          .put(options.getUsernameField(), 1)
+          .put(options.getRoleField(), 1)
+          .put(options.getPermissionField(), new JsonObject()
+            .put("$reduce", new JsonObject()
+              .put("input", "$joinedRoles." + options.getRolePermissionField())
+              .put("initialValue", new JsonObject()
+                // don't fail if no permissions field on user or if non array value
+                .put("$cond", new JsonObject()
+                  .put("if", new JsonObject()
+                    .put("$isArray", new JsonArray().add("$" + options.getPermissionField()))
+                  )
+                  .put("then", "$" + options.getPermissionField())
+                  .put("else", new JsonArray())
+                ))
+              .put("in", new JsonObject()
+                .put("$setUnion", new JsonArray().add("$$value").add(
+                    // don't fail if no permissions field on role or if non array value
+                    new JsonObject()
+                      .put("$cond", new JsonObject()
+                        .put("if", new JsonObject()
+                          .put("$isArray", new JsonArray().add("$$this"))
+                        )
+                        .put("then", "$$this")
+                        .put("else", new JsonArray())
+                      )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+      // make sure we get a single object containing all objects as a result (in case of duplicate usernames)
+      .add(new JsonObject()
+        .put("$group", new JsonObject()
+          .put("_id", "")
+          .put("users", new JsonObject()
+            .put("$push", "$$ROOT")
+          )
+        )
+      );
+    return result;
+  }
+
 }

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthorizationImpl.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthorizationImpl.java
@@ -166,7 +166,7 @@ public class MongoAuthorizationImpl implements MongoAuthorization {
         [{$match: {
           "username": "tim"
         }}, {$lookup: {
-          from: 'role',
+          from: 'roles',
           localField: 'roles',
           foreignField: 'rolename',
           as: 'joinedRoles'

--- a/vertx-auth-mongo/src/test/java/io/vertx/ext/auth/mongo/test/MongoAuthorizationWithRolesTest.java
+++ b/vertx-auth-mongo/src/test/java/io/vertx/ext/auth/mongo/test/MongoAuthorizationWithRolesTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.auth.mongo.test;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
+import io.vertx.ext.auth.authorization.RoleBasedAuthorization;
+import io.vertx.ext.auth.mongo.MongoAuthorization;
+import io.vertx.ext.auth.mongo.MongoAuthorizationOptions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.model.InitializationError;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Testing MongoAuth with no encryption for the user password
+ *
+ * @author mremme
+ */
+
+public class MongoAuthorizationWithRolesTest extends MongoAuthorizationTest {
+  private static final Logger log = LoggerFactory.getLogger(MongoAuthorizationWithRolesTest.class);
+
+  protected MongoAuthorization authorizationProvider;
+
+  public MongoAuthorizationWithRolesTest() {
+    authorizationOptions = new MongoAuthorizationOptions().setReadRolePermissions(true);
+  }
+
+  @Test
+  public void testAuthoriseWithRolePermission() {
+    // "sudo" permission is defined on "superadmin" role
+    // read role permissions is enabled above
+    assertTrue(authorizationOptions.isReadRolePermissions());
+    // so tim must not have the sudo permission
+    JsonObject authInfo = new JsonObject();
+    authInfo.put(authenticationOptions.getUsernameField(), "tim").put(authenticationOptions.getPasswordField(), "sausages");
+    getAuthenticationProvider().authenticate(authInfo, onSuccess(user -> {
+      assertNotNull(user);
+      fillUserAuthorizations(user, onSuccess(has -> {
+        assertTrue(PermissionBasedAuthorization.create("sudo").match(user));
+        testComplete();
+      }));
+    }));
+    await();
+  }
+
+}

--- a/vertx-auth-mongo/src/test/java/io/vertx/ext/auth/mongo/test/MongoBaseTest.java
+++ b/vertx-auth-mongo/src/test/java/io/vertx/ext/auth/mongo/test/MongoBaseTest.java
@@ -30,6 +30,7 @@ import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.mongo.MongoAuthentication;
 import io.vertx.ext.auth.mongo.MongoAuthenticationOptions;
+import io.vertx.ext.auth.mongo.MongoAuthorizationOptions;
 import io.vertx.ext.mongo.MongoClient;
 import io.vertx.test.core.VertxTestBase;
 import org.junit.AfterClass;
@@ -232,6 +233,25 @@ public abstract class MongoBaseTest extends VertxTestBase {
     getMongoClient().find(collectionName, new JsonObject(), res -> {
       if (res.succeeded()) {
         log.info(res.result().size() + " users found: " + res.result());
+
+      } else {
+        log.error("", res.cause());
+        buffer.append("false");
+      }
+      intLatch.countDown();
+    });
+    awaitLatch(intLatch);
+    return buffer.length() == 0;
+  }
+
+  protected boolean verifyRoleData(MongoAuthorizationOptions authorizationOptions) throws Exception {
+    final StringBuffer buffer = new StringBuffer();
+    CountDownLatch intLatch = new CountDownLatch(1);
+    String collectionName = authorizationOptions.getRoleCollectionName();
+    log.info("verifyRoleData in " + collectionName);
+    getMongoClient().find(collectionName, new JsonObject(), res -> {
+      if (res.succeeded()) {
+        log.info(res.result().size() + " roles found: " + res.result());
 
       } else {
         log.error("", res.cause());


### PR DESCRIPTION


Motivation:

This is a first proposal. 
I have modified the `MongoAuthorizationTest` to create and initialize a roles collection with a `superadmin` role having a `sudo` permission. 
I have added a new `testAuthoriseWithRolePermission` method to `MongoAuthorizationTest` showing that the "read roles" behavior is disabled by default: `tim` does not have the `sudo` permission event if he has the `superadmin` role.

The new `MongoAuthorizationWithRolesTest` test extends `MongoAuthorizationTest`, enables the "read roles" behavior, overrides the `testAuthoriseWithRolePermission` and modifies it expectations:  `tim` now has the `sudo` permission.


