### PR TITLE
Adding the missing package-info.java

### DIFF
--- a/vertx-auth-otp/src/main/java/io/vertx/ext/auth/otp/package-info.java
+++ b/vertx-auth-otp/src/main/java/io/vertx/ext/auth/otp/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+@ModuleGen(name = "vertx-auth-otp", groupPackage = "io.vertx")
+package io.vertx.ext.auth.otp;
+
+import io.vertx.codegen.annotations.ModuleGen;


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

For codegen of polyglot languages, we require a package-info.java