### PR TITLE
Fix #534: Legacy SHA512 should remain uppercase

### DIFF
--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/DefaultHashStrategy.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/DefaultHashStrategy.java
@@ -184,7 +184,7 @@ public class DefaultHashStrategy implements HashStrategy {
       switch (algorithm) {
         case SHA512:
           String concat = (salt == null ? "" : salt) + password;
-          return base16Encode(md.digest(concat.getBytes(StandardCharsets.UTF_8)));
+          return base16Encode(md.digest(concat.getBytes(StandardCharsets.UTF_8))).toUpperCase();
         case PBKDF2:
           PBEKeySpec spec = new PBEKeySpec(
             password.toCharArray(),

--- a/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthenticationImpl.java
+++ b/vertx-auth-mongo/src/main/java/io/vertx/ext/auth/mongo/impl/MongoAuthenticationImpl.java
@@ -30,6 +30,8 @@ import io.vertx.ext.auth.impl.UserImpl;
 import io.vertx.ext.auth.mongo.*;
 import io.vertx.ext.mongo.MongoClient;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.List;
 import java.util.Map;
 
@@ -182,7 +184,7 @@ public class MongoAuthenticationImpl implements MongoAuthentication {
       }
 
       String givenPassword = this.legacyStrategy.computeHash(password, user);
-      return hash.equals(givenPassword);
+      return MessageDigest.isEqual(hash.getBytes(StandardCharsets.UTF_8), givenPassword.getBytes(StandardCharsets.UTF_8));
     } else {
       return strategy.verify(hash, password);
     }


### PR DESCRIPTION
Motivation:

Leacy hashing should keep hash in uppercase also for SHA512