### PR TITLE
Fix #538: Add the openssl boundaries to the public key

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/KeycloakAuth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/KeycloakAuth.java
@@ -104,7 +104,12 @@ public interface KeycloakAuth extends OpenIDConnectAuth {
     if (config.containsKey("realm-public-key")) {
       options.addPubSecKey(new PubSecKeyOptions()
         .setAlgorithm("RS256")
-        .setBuffer(config.getString("realm-public-key")));
+        .setBuffer(
+          // wrap the key with the right boundaries:
+          "-----BEGIN PUBLIC KEY-----\n" +
+          config.getString("realm-public-key") +
+          "\n-----END PUBLIC KEY-----\n"
+      ));
     }
 
     return OAuth2Auth

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/KeycloakFromJsonTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/KeycloakFromJsonTest.java
@@ -1,0 +1,34 @@
+package io.vertx.ext.auth.test.oauth2;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.oauth2.OAuth2FlowType;
+import io.vertx.ext.auth.oauth2.providers.*;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class KeycloakFromJsonTest {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+  @Test
+  public void testCreateFromJson() {
+    JsonObject keycloakJson = new JsonObject()
+      .put("realm", "master")
+      .put("realm-public-key", "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqGQkaBkiZWpUjFOuaabgfXgjzZzfJd0wozrS1czX5qHNKG3P79P/UtZeR3wGN8r15jVYiH42GMINMs7R7iP5Mbm1iImge5p/7/dPmXirKOKOBhjA3hNTiV5BlPDTQyiuuTAUEms5dY4+moswXo5zM4q9DFu6B7979o+v3kX6ZB+k3kNhP08wH82I4eJKoenN/0iCT7ALoG3ysEJf18+HEysSnniLMJr8R1pYF2QRFlqaDv3Mqyp7ipxYkt4ebMCgE7aDzT6OrfpyPowObpdjSMTUXpcwIcH8mIZCWFmyfF675zEeE0e+dHKkL1rPeCI7rr7Bqc5+1DS5YM54fk8xQwIDAQAB")
+      .put("auth-server-url", "http://localhost:9000/auth")
+      .put("ssl-required", "external")
+      .put("resource", "frontend")
+      .put("credentials", new JsonObject()
+        .put("secret", "2fbf5e18-b923-4a83-9657-b4ebd5317f60"));
+
+    // Initialize the OAuth2 Library
+    OAuth2Auth oauth2 = KeycloakAuth
+      .create(rule.vertx(), OAuth2FlowType.PASSWORD, keycloakJson);
+  }
+}


### PR DESCRIPTION
Motivation:

When using keycloak without discovery, the public key should be wrapped with the right openssl boundaries.