### PR TITLE
Use passwordProtection to read MAC keys from keystore

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
@@ -144,7 +144,7 @@ public final class JWK {
     // load MACs
     for (String alias : Arrays.asList("HS256", "HS384", "HS512")) {
       try {
-        final Key secretKey = keyStore.getKey(alias, keyStorePassword.toCharArray());
+        final Key secretKey = keyStore.getKey(alias, passwordProtection == null ? keyStorePassword.toCharArray() : passwordProtection.get(alias).toCharArray());
         // key store does not have the requested algorithm
         if (secretKey == null) {
           continue;


### PR DESCRIPTION
Use the passwordProtection object if not null to supply keys for MAC keys instead of using the keystore password all the time. This is consistent with how asymmetric keys password is supplied.
