### PR TITLE
Ensure that the PRNG works with and without context

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
@@ -94,7 +94,7 @@ public interface VertxContextPRNG {
       }
 
       return random;
-    } catch (RuntimeException e) {
+    } catch (UnsupportedOperationException e) {
       // Access to the current context is probably blocked
       Vertx vertx = context.owner();
       if (vertx != null) {

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
@@ -46,7 +46,7 @@ public interface VertxContextPRNG {
    * the VertxContextPRNG falls back to instantiate a new instance of the PRNG per call.
    *
    * @return A secure non blocking random number generator.
-   * @throws IllegalStateException when there is no context available.
+   * @throws IllegalStateException when there is no {@link Context} instance available.
    */
   static VertxContextPRNG current() {
     final Context currentContext = Vertx.currentContext();
@@ -65,7 +65,8 @@ public interface VertxContextPRNG {
    * the VertxContextPRNG falls back to instantiate a new instance of the PRNG per call.
    *
    * @param context a Vert.x context.
-   * @return A secure non blocking random number generator, or {@code null} if context access fails.
+   * @return A secure non blocking random number generator
+   * @throws IllegalStateException when there is no {@link Vertx} instance available.
    */
   @GenIgnore
   static VertxContextPRNG current(final Context context) {

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/VertxContextPRNG.java
@@ -42,6 +42,9 @@ public interface VertxContextPRNG {
    * Get or create a secure non blocking random number generator using the current vert.x context. If there is no
    * current context (i.e.: not running on the eventloop) then a {@link java.lang.IllegalStateException} is thrown.
    *
+   * Note, if a context isn't allowed to be used, for example, exceptions are thrown on getting and putting data,
+   * the VertxContextPRNG falls back to instantiate a new instance of the PRNG per call.
+   *
    * @return A secure non blocking random number generator.
    * @throws IllegalStateException when there is no context available.
    */
@@ -57,6 +60,9 @@ public interface VertxContextPRNG {
   /**
    * Get or create a secure non blocking random number generator using the provided vert.x context. This method will not
    * throw an exception.
+   *
+   * Note, if a context isn't allowed to be used, for example, exceptions are thrown on getting and putting data,
+   * the VertxContextPRNG falls back to instantiate a new instance of the PRNG per call.
    *
    * @param context a Vert.x context.
    * @return A secure non blocking random number generator, or {@code null} if context access fails.
@@ -102,6 +108,9 @@ public interface VertxContextPRNG {
    * Get or create a secure non blocking random number generator using the current vert.x instance. Since the context
    * might be different this method will attempt to use the current context first if available and then fall back to
    * create a new instance of the PRNG.
+   *
+   * Note, if a context isn't allowed to be used, for example, exceptions are thrown on getting and putting data,
+   * the VertxContextPRNG falls back to instantiate a new instance of the PRNG per call.
    *
    * @param vertx a Vert.x instance.
    * @return A secure non blocking random number generator.

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/VertxContextPRNGTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/VertxContextPRNGTest.java
@@ -1,0 +1,48 @@
+package io.vertx.ext.auth;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Proxy;
+
+import static org.junit.Assert.*;
+
+@RunWith(VertxUnitRunner.class)
+public class VertxContextPRNGTest {
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+  @Test
+  public void testPRNGQuarkusContextAccessNotAllowed() {
+
+    final Vertx vertx = rule.vertx();
+
+    Context context = (Context) Proxy.newProxyInstance(
+      VertxContextPRNGTest.class.getClassLoader(),
+      new Class[] { Context.class },
+      (proxy, method, methodArgs) -> {
+        switch (method.getName()) {
+          case "get":
+          case "put":
+          case "remove":
+            // mimic Quarkus behavior
+            throw new UnsupportedOperationException("Access to Context.put(), Context.get() and Context.remove() are forbidden as it can leak data between unrelated processing. Use Context.putLocal(), Context.getLocal() and Context.removeLocal() instead. Note that these methods can only be used from a 'duplicated' Context, and so may not be available everywhere.");
+          case "owner":
+            return vertx;
+          case "equals":
+            return false;
+          default:
+            return null;
+        }
+      });
+
+    assertNotNull(VertxContextPRNG.current(context));
+  }
+
+}


### PR DESCRIPTION
Motivation:

Downstream projects (Quarkus) block access to the vert.x context. Even though PRNG was built to avoid duplication, we cannot throw exceptions as it would block applications from starting.

The behavior is changed to allow running without a context and fall back to having multiple instances.
