### PR TITLE
Replace JDBC with SQL Client

### DIFF
--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthentication.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthentication.java
@@ -24,6 +24,8 @@ import io.vertx.ext.jdbc.JDBCClient;
 import java.util.Map;
 
 /**
+ * @deprecated Please use {@code vertx-auth-sql-client} instead.
+ *
  * Factory interface for creating {@link io.vertx.ext.auth.authentication.AuthenticationProvider} instances that use the Vert.x JDBC client.
  *
  * By default the hashing strategy is SHA-512. If you're already running in production this is backwards
@@ -33,6 +35,7 @@ import java.util.Map;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @VertxGen
+@Deprecated
 public interface JDBCAuthentication extends AuthenticationProvider {
 
   /**

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthenticationOptions.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthenticationOptions.java
@@ -20,10 +20,13 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.json.JsonObject;
 
 /**
+ * @deprecated Please use {@code vertx-auth-sql-client} instead.
+ *
  * Options configuring JDBC authentication.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
+@Deprecated
 @DataObject(generateConverter = true)
 public class JDBCAuthenticationOptions {
 

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthorization.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthorization.java
@@ -22,10 +22,13 @@ import io.vertx.ext.auth.jdbc.impl.JDBCAuthorizationImpl;
 import io.vertx.ext.jdbc.JDBCClient;
 
 /**
+ * @deprecated Please use {@code vertx-auth-sql-client} instead.
+ *
  * Factory interface for creating {@link AuthorizationProvider} instances that use the Vert.x JDBC client.
  *
  * @author <a href="mail://stephane.bastian.dev@gmail.com">Stephane Bastian</a>
  */
+@Deprecated
 @VertxGen
 public interface JDBCAuthorization extends AuthorizationProvider {
 

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthorizationOptions.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCAuthorizationOptions.java
@@ -19,10 +19,13 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
 /**
+ * @deprecated Please use {@code vertx-auth-sql-client} instead.
+ *
  * Options configuring JDBC authentication.
  *
  * @author <a href="mailto:julien@julienviet.com">Julien Viet</a>
  */
+@Deprecated
 @DataObject(generateConverter = true)
 public class JDBCAuthorizationOptions {
   /**

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCUserUtil.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/JDBCUserUtil.java
@@ -27,10 +27,13 @@ import io.vertx.ext.jdbc.JDBCClient;
 import java.util.Map;
 
 /**
+ * @deprecated Please use {@code vertx-auth-sql-client} instead.
+ *
  * Utility to create users/roles/permissions. This is a helper class and not intended to be a full user
  * management utility. While the standard authentication and authorization interfaces will require usually
  * read only access to the database, in order to use this API a full read/write access must be granted.
  */
+@Deprecated
 @VertxGen
 public interface JDBCUserUtil {
 

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCAuthImpl.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCAuthImpl.java
@@ -39,6 +39,7 @@ import io.vertx.ext.jdbc.JDBCClient;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
+@Deprecated
 public class JDBCAuthImpl implements AuthProvider, JDBCAuth {
 
   private final JDBCClient client;

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCAuthenticationImpl.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCAuthenticationImpl.java
@@ -39,6 +39,7 @@ import io.vertx.ext.sql.SQLConnection;
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
+@Deprecated
 public class JDBCAuthenticationImpl implements JDBCAuthentication {
 
   private final HashingStrategy strategy = HashingStrategy.load();

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCAuthorizationImpl.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCAuthorizationImpl.java
@@ -19,6 +19,7 @@ import io.vertx.ext.jdbc.JDBCClient;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.sql.SQLConnection;
 
+@Deprecated
 public class JDBCAuthorizationImpl implements JDBCAuthorization {
 
   /**

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCUserUtilImpl.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/impl/JDBCUserUtilImpl.java
@@ -27,6 +27,7 @@ import java.security.SecureRandom;
 
 import static io.vertx.ext.auth.impl.Codec.base64Encode;
 
+@Deprecated
 public class JDBCUserUtilImpl implements JDBCUserUtil {
 
   private static final String INSERT_USER = "INSERT INTO user (username, password) VALUES (?, ?)";

--- a/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/package-info.java
+++ b/vertx-auth-jdbc/src/main/java/io/vertx/ext/auth/jdbc/package-info.java
@@ -14,6 +14,7 @@
  *  You may elect to redistribute this code under either of these licenses.
  */
 
+@Deprecated
 @ModuleGen(name = "vertx-auth-jdbc", groupPackage = "io.vertx")
 package io.vertx.ext.auth.jdbc;
 

--- a/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/LDAPAuthProvider.java
+++ b/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/LDAPAuthProvider.java
@@ -36,6 +36,7 @@ import io.vertx.core.json.JsonObject;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
+@Deprecated
 public class LDAPAuthProvider extends ShiroAuthProviderImpl {
 
   public static Realm createRealm(JsonObject config) {

--- a/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/PropertiesAuthProvider.java
+++ b/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/PropertiesAuthProvider.java
@@ -30,6 +30,7 @@ import static io.vertx.ext.auth.shiro.PropertiesProviderConstants.PROPERTIES_PRO
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
+@Deprecated
 public class PropertiesAuthProvider extends ShiroAuthProviderImpl {
 
   private static String resolve(String resource) {

--- a/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/ShiroAuthProviderImpl.java
+++ b/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/impl/ShiroAuthProviderImpl.java
@@ -45,6 +45,7 @@ import io.vertx.ext.auth.shiro.ShiroAuthOptions;
  *
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
+@Deprecated
 public class ShiroAuthProviderImpl implements ShiroAuth {
 
   private final Vertx vertx;

--- a/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/package-info.java
+++ b/vertx-auth-shiro/src/main/java/io/vertx/ext/auth/shiro/package-info.java
@@ -13,7 +13,7 @@
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
-
+@Deprecated
 @ModuleGen(name = "vertx-auth-shiro", groupPackage = "io.vertx")
 package io.vertx.ext.auth.shiro;
 

--- a/vertx-auth-shiro/src/main/java/org/apache/shiro/realm/GetAuthorizationsHack.java
+++ b/vertx-auth-shiro/src/main/java/org/apache/shiro/realm/GetAuthorizationsHack.java
@@ -16,6 +16,7 @@ import io.vertx.ext.auth.authorization.Authorization;
 import io.vertx.ext.auth.authorization.RoleBasedAuthorization;
 import io.vertx.ext.auth.authorization.WildcardPermissionBasedAuthorization;
 
+@Deprecated
 public class GetAuthorizationsHack {
 
   public static Set<Authorization> getAuthorizations(SecurityManager securityManager, Subject subject) {

--- a/vertx-auth-sql-client/pom.xml
+++ b/vertx-auth-sql-client/pom.xml
@@ -56,5 +56,29 @@
       <artifactId>vertx-mysql-client</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-jdbc-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>6.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-api</artifactId>
+      <version>1.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-pool</artifactId>
+      <version>1.12</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/vertx-auth-sql-client/src/test/java/io/vertx/ext/auth/sqlclient/MySQLJDBCTest.java
+++ b/vertx-auth-sql-client/src/test/java/io/vertx/ext/auth/sqlclient/MySQLJDBCTest.java
@@ -1,0 +1,200 @@
+package io.vertx.ext.auth.sqlclient;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authentication.AuthenticationProvider;
+import io.vertx.ext.auth.authorization.AuthorizationProvider;
+import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
+import io.vertx.ext.auth.authorization.RoleBasedAuthorization;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.jdbcclient.JDBCConnectOptions;
+import io.vertx.jdbcclient.JDBCPool;
+import io.vertx.sqlclient.PoolOptions;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+
+@RunWith(VertxUnitRunner.class)
+public class MySQLJDBCTest {
+
+  @ClassRule
+  public static GenericContainer<?> container = new GenericContainer<>("mysql:5.7")
+    .withEnv("MYSQL_USER", "mysql")
+    .withEnv("MYSQL_PASSWORD", "password")
+    .withEnv("MYSQL_ROOT_PASSWORD", "password")
+    .withEnv("MYSQL_DATABASE", "testschema")
+    .withExposedPorts(3306)
+    .withClasspathResourceMapping("mysql-auth-ddl-test.sql", "/docker-entrypoint-initdb.d/init.sql", BindMode.READ_ONLY);
+
+  @Rule
+  public RunTestOnContext rule = new RunTestOnContext();
+
+  private JDBCPool mysql;
+
+  @Before
+  public void before() {
+    // Create the client pool
+    mysql = JDBCPool.pool(
+      rule.vertx(),
+      // default config
+      new JDBCConnectOptions()
+        .setJdbcUrl("jdbc:mysql://" + container.getContainerIpAddress() + ":" + container.getMappedPort(3306) + "/testschema?useSSL=false&serverTimezone=UTC&useLegacyDatetimeCode=false")
+        .setUser("mysql")
+        .setPassword("password"),
+      // default pool config
+      new PoolOptions()
+        .setMaxSize(5));
+  }
+
+  @After
+  public void after() {
+    mysql.close();
+  }
+
+  @Test
+  public void testAuthenticate(TestContext should) {
+    final Async test = should.async();
+
+    AuthenticationProvider authn = SqlAuthentication.create(mysql);
+
+    JsonObject authInfo = new JsonObject();
+    authInfo.put("username", "lopus").put("password", "secret");
+
+    authn.authenticate(authInfo, authenticate -> {
+      should.assertTrue(authenticate.succeeded());
+      should.assertNotNull(authenticate.result());
+      should.assertEquals("lopus", authenticate.result().principal().getString("username"));
+      test.complete();
+    });
+  }
+
+  @Test
+  public void testAuthenticateBadPassword(TestContext should) {
+    final Async test = should.async();
+
+    AuthenticationProvider authn = SqlAuthentication.create(mysql);
+
+    JsonObject authInfo = new JsonObject();
+    authInfo.put("username", "lopus").put("password", "s3cr3t");
+
+    authn.authenticate(authInfo, authenticate -> {
+      should.assertTrue(authenticate.failed());
+      should.assertNull(authenticate.result());
+      should.assertEquals("Invalid username/password", authenticate.cause().getMessage());
+      test.complete();
+    });
+  }
+
+  @Test
+  public void testAuthenticateBadUser(TestContext should) {
+    final Async test = should.async();
+
+    AuthenticationProvider authn = SqlAuthentication.create(mysql);
+
+    JsonObject authInfo = new JsonObject();
+    authInfo.put("username", "lopes").put("password", "s3cr3t");
+
+    authn.authenticate(authInfo, authenticate -> {
+      should.assertTrue(authenticate.failed());
+      should.assertNull(authenticate.result());
+      should.assertEquals("Invalid username/password", authenticate.cause().getMessage());
+      test.complete();
+    });
+  }
+
+  @Test
+  public void testAuthoriseHasRole(TestContext should) {
+    final Async test = should.async();
+
+    JsonObject authInfo = new JsonObject();
+    authInfo.put("username", "lopus").put("password", "secret");
+
+    AuthenticationProvider authn = SqlAuthentication.create(mysql);
+
+    authn.authenticate(authInfo, authenticate -> {
+      should.assertTrue(authenticate.succeeded());
+      final User user = authenticate.result();
+      should.assertNotNull(user);
+      AuthorizationProvider authz = SqlAuthorization.create(mysql);
+      authz.getAuthorizations(user, getAuthorizations -> {
+        should.assertTrue(getAuthorizations.succeeded());
+        // attest
+        should.assertTrue(RoleBasedAuthorization.create("dev").match(user));
+        test.complete();
+      });
+    });
+  }
+
+  @Test
+  public void testAuthoriseNotHasRole(TestContext should) {
+    final Async test = should.async();
+
+    JsonObject authInfo = new JsonObject();
+    authInfo.put("username", "lopus").put("password", "secret");
+
+    AuthenticationProvider authn = SqlAuthentication.create(mysql);
+
+    authn.authenticate(authInfo, authenticate -> {
+      should.assertTrue(authenticate.succeeded());
+      final User user = authenticate.result();
+      should.assertNotNull(user);
+      AuthorizationProvider authz = SqlAuthorization.create(mysql);
+      authz.getAuthorizations(user, getAuthorizations -> {
+        should.assertTrue(getAuthorizations.succeeded());
+        // attest
+        should.assertFalse(RoleBasedAuthorization.create("manager").match(user));
+        test.complete();
+      });
+    });
+  }
+
+  @Test
+  public void testAuthoriseHasPermission(TestContext should) {
+    final Async test = should.async();
+
+    JsonObject authInfo = new JsonObject();
+    authInfo.put("username", "lopus").put("password", "secret");
+
+    AuthenticationProvider authn = SqlAuthentication.create(mysql);
+
+    authn.authenticate(authInfo, authenticate -> {
+      should.assertTrue(authenticate.succeeded());
+      final User user = authenticate.result();
+      should.assertNotNull(user);
+      AuthorizationProvider authz = SqlAuthorization.create(mysql);
+      authz.getAuthorizations(user, getAuthorizations -> {
+        should.assertTrue(getAuthorizations.succeeded());
+        // attest
+        should.assertTrue(PermissionBasedAuthorization.create("commit_code").match(user));
+        test.complete();
+      });
+    });
+  }
+
+  @Test
+  public void testAuthoriseNotHasPermission(TestContext should) {
+    final Async test = should.async();
+
+    JsonObject authInfo = new JsonObject();
+    authInfo.put("username", "lopus").put("password", "secret");
+
+    AuthenticationProvider authn = SqlAuthentication.create(mysql);
+
+    authn.authenticate(authInfo, authenticate -> {
+      should.assertTrue(authenticate.succeeded());
+      final User user = authenticate.result();
+      should.assertNotNull(user);
+      AuthorizationProvider authz = SqlAuthorization.create(mysql);
+      authz.getAuthorizations(user, getAuthorizations -> {
+        should.assertTrue(getAuthorizations.succeeded());
+        // attest
+        should.assertFalse(PermissionBasedAuthorization.create("eat_sandwich").match(user));
+        test.complete();
+      });
+    });
+  }
+}


### PR DESCRIPTION
Motivation:

Currently we have 2 ways of achieving the same result. This PR shows that we can achive the same result just with one module.

If we all agree we, can deprecate the `vertx-auth-jdbc` like shiro.