### PR TITLE
#583 Do not mutate the jwt object provided by the user

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -441,7 +441,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
 
         case AUTH_JWT:
           params
-            .put("assertion", jwt.sign(oauth2Credentials.getJwt(), config.getJWTOptions()));
+            .put("assertion", jwt.sign(oauth2Credentials.getJwt().copy(), config.getJWTOptions()));
 
           if (oauth2Credentials.getScopes() != null) {
             params.put("scope", String.join(config.getScopeSeparator(), oauth2Credentials.getScopes()));


### PR DESCRIPTION
Motivation:

#583  Avoid mutating the JWT object passed by the user and fix the generation of `iat` field which only worked on the first call.