### PR TITLE
Allow opaque tokens

### DIFF
--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/JWKTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/JWKTest.java
@@ -143,7 +143,7 @@ public class JWKTest {
     try {
       jwt.decode("eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc0MjQzMGI2ZDRkZjQxMzVlM2JkOTgyYWM2YmVjNDNhMTE4ODhkMWIifQ.eyJhenAiOiI1ODUyMDUyMjk1NzctZGlxZ2l1NWkwbjNoN2hzZmF0cG91MzY0OXVvaGduOWkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI1ODUyMDUyMjk1NzctZGlxZ2l1NWkwbjNoN2hzZmF0cG91MzY0OXVvaGduOWkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDI1ODI3NDEyNjA5NDc1ODQxNDQiLCJhdF9oYXNoIjoicGJWZE1Nb3l6UDl5UU9sMk54bkJDUSIsImlzcyI6ImFjY291bnRzLmdvb2dsZS5jb20iLCJpYXQiOjE1MDc1NzgyMDMsImV4cCI6MTUwNzU4MTgwM30.cU21Gu1jEcAONlQ0vf0ju8W7gsdyzPo-U3U6JCFaVqYqF5J2JmhCSk_-kJcY19WKyg8iwibOSNuuQE8PP0eCiIWDY-fq_3wOoO4IBUa5zlmTMNdz9Af4vH2h-optaG89tXE89J_-D2TjkKDdu1nPVLefX6E95vjb3P9LP5LfFJV53zT_deacFn4XiyCVMBl7sfNE0A6YG3PmZkVNgyIYJCv21bB5N_YtWTSEV_8YSFaJwDcEihqBGiFe3fO3k9-A237HuKevBRfo_xAyIQXnCHiLg8eETGTK3sfRh_ugxMI0jvgt4hBZQTioGjnaMRmQxaiJ_3IOrpSJeMu_JIg8-g");
       fail("Should not decode because the certificates are expired");
-    } catch (RuntimeException e) {
+    } catch (Exception e) {
       // OK
     }
   }
@@ -172,7 +172,7 @@ public class JWKTest {
   }
 
   @Test
-  public void loadAzure() {
+  public void loadAzure() throws Exception {
     Vertx vertx = Vertx.vertx();
     JsonObject azure = new JsonObject(vertx.fileSystem()
       .readFileBlocking("azure.json"));
@@ -210,7 +210,7 @@ public class JWKTest {
   }
 
   @Test
-  public void testOKP() {
+  public void testOKP() throws Exception {
     assumeTrue("JVM doesn't support EdDSA", getVersion() >= 15);
     JsonObject jwk = new JsonObject()
       .put("kty", "OKP")
@@ -229,7 +229,7 @@ public class JWKTest {
   }
 
   @Test
-  public void testOKPInterop() {
+  public void testOKPInterop() throws Exception {
     assumeTrue("JVM doesn't support EdDSA", getVersion() >= 15);
 
     // this key and token were generated from
@@ -270,7 +270,7 @@ public class JWKTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void publicECKSignZero() {
+  public void publicECKSignZero() throws Exception {
     JsonObject jwk = new JsonObject()
       .put("kty", "EC")
       .put("crv", "P-256")

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/JWTTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/JWTTest.java
@@ -119,7 +119,7 @@ public class JWTTest {
   }
 
   @Test
-  public void testECKeyPair() {
+  public void testECKeyPair() throws Exception {
     JWT vk = new JWT()
       .addJWK(new JWK(
         new PubSecKeyOptions()
@@ -137,7 +137,7 @@ public class JWTTest {
   }
 
   @Test(expected = NoSuchKeyIdException.class)
-  public void testECKeyPairWrongKid() {
+  public void testECKeyPairWrongKid() throws Exception {
     JWT vk = new JWT()
       .addJWK(new JWK(
         new PubSecKeyOptions()
@@ -156,7 +156,7 @@ public class JWTTest {
   }
 
   @Test
-  public void testGoogleCerts() {
+  public void testGoogleCerts() throws Exception {
     JWT jwt = new JWT();
     jwt.addJWK(new JWK(new PubSecKeyOptions().setAlgorithm("RS256").setBuffer("-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIIZtJv8PyRUgowDQYJKoZIhvcNAQEFBQAwNjE0MDIGA1UE\nAxMrZmVkZXJhdGVkLXNpZ25vbi5zeXN0ZW0uZ3NlcnZpY2VhY2NvdW50LmNvbTAe\nFw0xNzEwMDgxMTQzMzRaFw0xNzEwMTExMjEzMzRaMDYxNDAyBgNVBAMTK2ZlZGVy\nYXRlZC1zaWdub24uc3lzdGVtLmdzZXJ2aWNlYWNjb3VudC5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC6fNn5kfLZQ43Z+ZTqFMUF+dN2L2BphQKz\ngaWCsyzyJYwEySgMxbO8cQgTlgZzcC1Rt6phWHMBkFQQNykSk/K0A8xaaNqFNNVz\neszR+XJ3IvCQGo8rS2K/LrNofGZrph00k6DZ7XJsWav0GotAwDd0H6IsNbFHCyRJ\n75ASzZr8fT8RJ9bQeTLoCsmwPXYBPeSvoWgZzOypbmLhohw0J7fBUbgVZ8fR3crh\nv6RDOp4/fDALWxCVPptFn0hMPeT2Dla9kbnPfVSWtciyvty5JJXnpuoqA6rLfEpM\nGYnMSk+SbD2R0W9O2LMRfoJ52qml+2s/aLpNKGJc2vLzDyH7CiavAgMBAAGjODA2\nMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMBYGA1UdJQEB/wQMMAoGCCsG\nAQUFBwMCMA0GCSqGSIb3DQEBBQUAA4IBAQAlDoCH/E43ruorgPIATCO++dOfOIb/\nn+NgE727UeK1acELi+dUjSdYEe+WXdY2sichgE1JqPrsMWFHCwHTUfVubmku5BTk\nlj9k6F9jKc+XDMra1w0KGSGrxwSqwYhkhSdMOGGa9C3td+s7M/E4JV+XoQXAY3uE\naB0lO4c+pckDwU/LAGrMldogT3+zE+4NRS7p8dstnww3OIHUCFfytbhcY8sH4Vjq\ndMWGrv8R/1L0jXok8vFPEAwvXzVc3NeUClio0hOEmhTjbLgebsgToB1aNC1pnzmH\nTclVndTwDcnDkhImpvuWE1lX+KPkFJ54ixS4Bi2cqWud1aQ2Mqi7KHfK\n-----END CERTIFICATE-----\n")));
     jwt.addJWK(new JWK(new PubSecKeyOptions().setAlgorithm("RS256").setBuffer("-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIIeABc0/4wb7AwDQYJKoZIhvcNAQEFBQAwNjE0MDIGA1UE\nAxMrZmVkZXJhdGVkLXNpZ25vbi5zeXN0ZW0uZ3NlcnZpY2VhY2NvdW50LmNvbTAe\nFw0xNzEwMDkxMTQzMzRaFw0xNzEwMTIxMjEzMzRaMDYxNDAyBgNVBAMTK2ZlZGVy\nYXRlZC1zaWdub24uc3lzdGVtLmdzZXJ2aWNlYWNjb3VudC5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC3ICz+C7FKE4jbsRh/cZK1I9M5lXGlyvk8\nc72BuK3/uLwnRH5eSrooA1LEqwVdKV5MOTuHHnxWFb57yyBl8Ld3CGK/aeZYIGd6\niV8ym/jw6rCdJhkL6yCZ3/Xj3+Un+5Vf+ObjHd04X/GbwleFRcldJilpgwtt0PKT\n/JBl/lKqTzzH/HWzdp3tj5gfVJzj1NxfN4K0GSFDy/5pRYsT9NebFC/JoBgSXrEE\nZXaigqQsYiI+lTDL59TLq8XaaT0V1sfoHnspu3DikgO51eJBP3c0wB2CvXxk+vMl\nSQMsnDcsztiijGPwrpxrLwDyzsm3Rs7WI9kDHPeUeKhGX0/s9AnBAgMBAAGjODA2\nMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMBYGA1UdJQEB/wQMMAoGCCsG\nAQUFBwMCMA0GCSqGSIb3DQEBBQUAA4IBAQAiZt536sXwNXqUs92edWsQ+uiraJbl\nATuMSslrQhGJjUebmlpIUMe8Dv2dj+/bYK7gZyjUQKwjmtCJ+U8Z2Ec/v9yEqKpy\nzfYIOTF/17d31OvisnccIbjBL2X+b/OHsFDjaY5hZrs0mczr1ePaYlE/EsyIFEZC\nwGbgarp7FxlRrdJEBN8jnjUgK6Kig2GLtcQcHfkIjxmVDzgS47TAtxPNTBGQypWu\nbALTWt+WTAFpQGcW6pj9nOxuV2XB4RkFg7XrHtnBvad4/KAD/kp2if6BFyvwWcyQ\nzKqqKcjJHinaGWf7qlBLBJTQcZcWPJEzFdwBsHHejgU8vy9hR97rvU8s\n-----END CERTIFICATE-----\n")));
@@ -187,7 +187,7 @@ public class JWTTest {
   }
 
   @Test
-  public void testPSS() {
+  public void testPSS() throws Exception {
     // RSASSA-PSS is only available on >=11
     Assume.assumeTrue(getVersion() >= 11);
 
@@ -231,7 +231,7 @@ public class JWTTest {
   }
 
   @Test
-  public void testJWTWithX5c() {
+  public void testJWTWithX5c() throws Exception {
     JWT jwt = new JWT().allowEmbeddedKey(true);
 
     Buffer buffer = rule.vertx().fileSystem().readFileBlocking("toc.jwt");

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/impl/JWTAuthProviderImpl.java
@@ -39,10 +39,7 @@ import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
+import java.security.*;
 import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -144,7 +141,7 @@ public class JWTAuthProviderImpl implements JWTAuth {
     final JsonObject payload;
     try {
       payload = jwt.decode(authInfo.getToken());
-    } catch (RuntimeException e) {
+    } catch (SignatureException | RuntimeException e) {
       return Future.failedFuture(e);
     }
 

--- a/vertx-auth-oauth2/src/main/generated/io/vertx/ext/auth/oauth2/OAuth2OptionsConverter.java
+++ b/vertx-auth-oauth2/src/main/generated/io/vertx/ext/auth/oauth2/OAuth2OptionsConverter.java
@@ -75,6 +75,16 @@ public class OAuth2OptionsConverter {
             obj.setJwkPath((String)member.getValue());
           }
           break;
+        case "jwks":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<io.vertx.core.json.JsonObject> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof JsonObject)
+                list.add(((JsonObject)item).copy());
+            });
+            obj.setJwks(list);
+          }
+          break;
         case "jwtOptions":
           if (member.getValue() instanceof JsonObject) {
             obj.setJWTOptions(new io.vertx.ext.auth.JWTOptions((io.vertx.core.json.JsonObject)member.getValue()));
@@ -189,6 +199,11 @@ public class OAuth2OptionsConverter {
     json.put("jwkMaxAgeInSeconds", obj.getJwkMaxAgeInSeconds());
     if (obj.getJwkPath() != null) {
       json.put("jwkPath", obj.getJwkPath());
+    }
+    if (obj.getJwks() != null) {
+      JsonArray array = new JsonArray();
+      obj.getJwks().forEach(item -> array.add(item));
+      json.put("jwks", array);
     }
     if (obj.getJWTOptions() != null) {
       json.put("jwtOptions", obj.getJWTOptions().toJson());

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
@@ -17,6 +17,7 @@
 package io.vertx.ext.auth.oauth2;
 
 import io.vertx.codegen.annotations.DataObject;
+import io.vertx.codegen.annotations.Fluent;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.impl.logging.Logger;
@@ -87,6 +88,7 @@ public class OAuth2Options {
   private JsonObject extraParams;
   // client config
   private HttpClientOptions httpClientOptions = new HttpClientOptions();
+  private List<JsonObject> jwks;
 
   public String getSite() {
     return site;
@@ -147,6 +149,12 @@ public class OAuth2Options {
     httpClientOptions = other.getHttpClientOptions();
     userAgent = other.getUserAgent();
     supportedGrantTypes = other.getSupportedGrantTypes();
+    final List<JsonObject> jwks = other.getJwks();
+    if (jwks != null) {
+      this.jwks = new ArrayList<>(jwks);
+    } else {
+      this.jwks = null;
+    }
     // compute paths with variables, at this moment it is only relevant that
     // the paths and site are properly computed
     replaceVariables(false);
@@ -666,5 +674,35 @@ public class OAuth2Options {
    */
   public void setJwkMaxAgeInSeconds(long jwkMaxAgeInSeconds) {
     this.jwkMaxAge = jwkMaxAgeInSeconds;
+  }
+
+  public List<JsonObject> getJwks() {
+    return jwks;
+  }
+
+  /**
+   * Sets the initial local JWKs
+   * @param jwks a json array as defined in https://tools.ietf.org/html/rfc7517#section-5
+   * @return self
+   */
+  @Fluent
+  public OAuth2Options setJwks(List<JsonObject> jwks) {
+    this.jwks = jwks;
+    return this;
+  }
+
+  /**
+   * Adds a local JWKs
+   * @param jwk a single keyas defined in https://tools.ietf.org/html/rfc7517#section-5
+   * @return self
+   */
+  @Fluent
+  public OAuth2Options addJwk(JsonObject jwk) {
+    if (this.jwks == null) {
+      this.jwks = new ArrayList<>();
+    }
+
+    this.jwks.add(jwk);
+    return this;
   }
 }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2API.java
@@ -30,6 +30,7 @@ import io.vertx.ext.auth.oauth2.OAuth2Options;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.security.SignatureException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -389,7 +390,7 @@ public class OAuth2API {
           try {
             // userInfo is expected to be a JWT
             userInfo = jwt.decode(body.toString(StandardCharsets.UTF_8));
-          } catch (RuntimeException e) {
+          } catch (SignatureException | RuntimeException e) {
             return Future.failedFuture(e);
           }
         } else if (reply.is("application/x-www-form-urlencoded") || reply.is("text/plain")) {

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/Oauth2TokenAudienceTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/Oauth2TokenAudienceTest.java
@@ -1,0 +1,131 @@
+package io.vertx.ext.auth.test.oauth2;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.JWTOptions;
+import io.vertx.ext.auth.PubSecKeyOptions;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authentication.TokenCredentials;
+import io.vertx.ext.auth.authorization.PermissionBasedAuthorization;
+import io.vertx.ext.auth.impl.http.SimpleHttpClient;
+import io.vertx.ext.auth.impl.jose.JWK;
+import io.vertx.ext.auth.jwt.JWTAuth;
+import io.vertx.ext.auth.jwt.JWTAuthOptions;
+import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.oauth2.OAuth2Options;
+import io.vertx.ext.auth.oauth2.authorization.ScopeAuthorization;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.UnsupportedEncodingException;
+
+@RunWith(VertxUnitRunner.class)
+public class Oauth2TokenAudienceTest {
+
+  @Rule
+  public final RunTestOnContext rule = new RunTestOnContext();
+
+  @Test
+  public void testGoodAudience(TestContext should) {
+    final Async test = should.async();
+
+    JsonObject jwk = new JsonObject()
+      .put("kty", "RSA")
+      .put("n", "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw")
+      .put("e", "AQAB")
+      .put("d", "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q")
+      .put("p", "83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs")
+      .put("q", "3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk")
+      .put("dp", "G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0")
+      .put("dq", "s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk")
+      .put("qi", "GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU")
+      .put("alg", "RS256")
+      .put("kid", "2011-04-29");
+
+    OAuth2Options options = new OAuth2Options()
+      .setClientId("client-id")
+      .setClientSecret("client-secret")
+      .addJwk(jwk)
+      .setJWTOptions(
+        new JWTOptions()
+          .addAudience("b")
+          .addAudience("d"));
+
+    JWTAuth jwt = JWTAuth.create(rule.vertx(), new JWTAuthOptions().addJwk(jwk));
+    OAuth2Auth oauth2 = OAuth2Auth.create(rule.vertx(), options);
+
+    JsonObject payload = new JsonObject()
+      .put("sub", "Paulo");
+
+    final String token = jwt.generateToken(payload,
+      new JWTOptions().setAlgorithm("RS256").addAudience("a").addAudience("b").addAudience("c"));
+
+    should.assertNotNull(token);
+
+    TokenCredentials authInfo = new TokenCredentials(token);
+
+    oauth2.authenticate(authInfo)
+      .onFailure(should::fail)
+      .onSuccess(res -> {
+        should.assertNotNull(res);
+        test.complete();
+      });
+  }
+
+  @Test
+  public void testBadAudience(TestContext should) {
+    final Async test = should.async();
+
+    JsonObject jwk = new JsonObject()
+      .put("kty", "RSA")
+      .put("n", "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw")
+      .put("e", "AQAB")
+      .put("d", "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q")
+      .put("p", "83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs")
+      .put("q", "3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk")
+      .put("dp", "G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0")
+      .put("dq", "s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk")
+      .put("qi", "GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU")
+      .put("alg", "RS256")
+      .put("kid", "2011-04-29");
+
+    OAuth2Options options = new OAuth2Options()
+      .setClientId("client-id")
+      .setClientSecret("client-secret")
+      .addJwk(jwk)
+      .setJWTOptions(
+        new JWTOptions()
+          .addAudience("e")
+          .addAudience("d"));
+
+    JWTAuth jwt = JWTAuth.create(rule.vertx(), new JWTAuthOptions().addJwk(jwk));
+    OAuth2Auth oauth2 = OAuth2Auth.create(rule.vertx(), options);
+
+    JsonObject payload = new JsonObject()
+      .put("sub", "Paulo");
+
+    final String token = jwt.generateToken(payload,
+      new JWTOptions().setAlgorithm("RS256").addAudience("a").addAudience("b").addAudience("c"));
+
+    should.assertNotNull(token);
+
+    TokenCredentials authInfo = new TokenCredentials(token);
+
+    oauth2.authenticate(authInfo)
+      .onFailure(err -> {
+        test.complete();
+      })
+      .onSuccess(res -> {
+        should.fail("Audience is incorrect");
+      });
+  }
+}

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/Oauth2TokenScopeTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/Oauth2TokenScopeTest.java
@@ -31,6 +31,7 @@ public class Oauth2TokenScopeTest {
   public final RunTestOnContext rule = new RunTestOnContext();
 
   private final static String JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InNjb3BlQSBzY29wZUIgc2NvcGVDIiwiZXhwIjo5OTk5OTk5OTk5LCJuYmYiOjAsImlhdCI6MTQ2NDkwNjY3MSwic3ViIjoiZjE4ODhmNGQtNTE3Mi00MzU5LWJlMGMtYWYzMzg1MDVkODZjIn0.7aJYjGVe4YfdnYTlQH_FYhRCjvctcE7DtWwzxXrbLmM";
+  private final static String JWT_INVALID_SIGNATURE = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InNjb3BlQSBzY29wZUIgc2NvcGVDIiwiZXhwIjo5OTk5OTk5OTk5LCJuYmYiOjAsImlhdCI6MTQ2NDkwNjY3MSwic3ViIjoiZjE4ODhmNGQtNTE3Mi00MzU5LWJlMGMtYWYzMzg1MDVkODZjIn0.7aJYjGVe4YfdnYTlQH_FYhRCjvctcE7DtWwzxXrbLm";
 
   private OAuth2Auth oauth2;
   private HttpServer server;
@@ -309,5 +310,56 @@ public class Oauth2TokenScopeTest {
           test.complete();
         }
       });
+  }
+
+  /*
+    Skip validation of access token if is opaque.
+   */
+  @Test
+  public void opaqueAccessTokenIsValidWithInvalidSignature(TestContext should) {
+    final Async test = should.async();
+    config = new JsonObject()
+      .put("token_type", "Bearer")
+      .put("access_token", JWT_INVALID_SIGNATURE)
+      .put("token", JWT_INVALID_SIGNATURE);
+
+    oauthConfig
+      .addPubSecKey(new PubSecKeyOptions().setAlgorithm("HS256").setBuffer("vertx"))
+      .setJWTOptions(new JWTOptions())
+      .setIntrospectionPath("/oauth/introspect")
+      .setExtraParameters(config);
+
+    oauth2 = OAuth2Auth.create(rule.vertx(), oauthConfig);
+
+    oauth2.authenticate(new TokenCredentials(JWT_INVALID_SIGNATURE))
+      .onComplete(res -> {
+        if (res.failed()) {
+          should.fail(res.cause());
+        } else {
+          User token = res.result();
+          should.assertFalse(token.expired());
+          test.complete();
+        }
+      });
+  }
+
+  @Test
+  public void accessTokenIsInvalidWithInvalidSignature(TestContext should) {
+    final Async test = should.async();
+    config = new JsonObject()
+      .put("token_type", "Bearer")
+      .put("access_token", JWT_INVALID_SIGNATURE)
+      .put("token", JWT_INVALID_SIGNATURE);
+
+    oauthConfig
+      .addPubSecKey(new PubSecKeyOptions().setAlgorithm("HS256").setBuffer("vertx"))
+      .setJWTOptions(new JWTOptions())
+      .setIntrospectionPath("/oauth/introspect")
+      .setExtraParameters(config);
+
+    oauth2 = OAuth2Auth.create(rule.vertx(), oauthConfig);
+    oauth2.authenticate(new TokenCredentials(JWT_INVALID_SIGNATURE))
+      .onSuccess(token -> test.complete())
+      .onFailure(should::fail);
   }
 }

--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OpenIDCDiscoveryTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OpenIDCDiscoveryTest.java
@@ -110,7 +110,6 @@ public class OpenIDCDiscoveryTest {
         // should merge not override!
         JWTOptions jwtOptions = config.getJWTOptions();
         should.assertEquals("api://client-id", jwtOptions.getAudience().get(0));
-        System.out.println(jwtOptions.getAudience());
         test.complete();
       });
   }

--- a/vertx-auth-webauthn/src/main/generated/io/vertx/ext/auth/webauthn/WebAuthnOptionsConverter.java
+++ b/vertx-auth-webauthn/src/main/generated/io/vertx/ext/auth/webauthn/WebAuthnOptionsConverter.java
@@ -50,6 +50,11 @@ public class WebAuthnOptionsConverter {
             obj.setPubKeyCredParams(list);
           }
           break;
+        case "relaxedSafetyNetIntegrityVeridict":
+          if (member.getValue() instanceof Boolean) {
+            obj.setRelaxedSafetyNetIntegrityVeridict((Boolean)member.getValue());
+          }
+          break;
         case "relyingParty":
           if (member.getValue() instanceof JsonObject) {
             obj.setRelyingParty(new io.vertx.ext.auth.webauthn.RelyingParty((io.vertx.core.json.JsonObject)member.getValue()));
@@ -124,6 +129,7 @@ public class WebAuthnOptionsConverter {
       obj.getPubKeyCredParams().forEach(item -> array.add(item.name()));
       json.put("pubKeyCredParams", array);
     }
+    json.put("relaxedSafetyNetIntegrityVeridict", obj.isRelaxedSafetyNetIntegrityVeridict());
     if (obj.getRelyingParty() != null) {
       json.put("relyingParty", obj.getRelyingParty().toJson());
     }


### PR DESCRIPTION
Motivation:

Fix #552
Fix #626 
Fix #465

Opaque tokens will not fill the logs anymore.

Behavior is now aligned with auth-jwt