### PR TITLE
Don't call IdP on bad JWT

### DIFF
--- a/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2IntrospectTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/ext/auth/test/oauth2/OAuth2IntrospectTest.java
@@ -143,6 +143,7 @@ public class OAuth2IntrospectTest {
           // clean time specific value
           principal.remove("expires_at");
           principal.remove("access_token");
+          principal.remove("opaque");
 
           final JsonObject assertion = fixtureIntrospect.copy();
 
@@ -178,6 +179,8 @@ public class OAuth2IntrospectTest {
           should.assertNotNull(token);
           // make a copy because later we need to original data
           JsonObject principal = token.principal().copy();
+          // clean time specific value
+          principal.remove("opaque");
 
           // clean up control
           final JsonObject assertion = fixtureGoogle.copy();


### PR DESCRIPTION
Motivation:

validation of raw tokens falls back to opaque when jwt issues happen. If the issues are valid, like signature mismatch or audience, there is no need to proceed as opaque saving a few network roundtrips