### PR TITLE
Update examples to prevent IOException - DerInputStream

### DIFF
--- a/vertx-auth-jwt/src/main/java/examples/AuthJWTExamples.java
+++ b/vertx-auth-jwt/src/main/java/examples/AuthJWTExamples.java
@@ -40,7 +40,8 @@ public class AuthJWTExamples {
     JWTAuthOptions config = new JWTAuthOptions()
       .setKeyStore(new KeyStoreOptions()
         .setPath("keystore.jceks")
-        .setPassword("secret"));
+        .setPassword("secret")
+        .setType("jceks"));
 
     AuthenticationProvider provider = JWTAuth.create(vertx, config);
   }
@@ -50,7 +51,8 @@ public class AuthJWTExamples {
     JWTAuthOptions config = new JWTAuthOptions()
       .setKeyStore(new KeyStoreOptions()
         .setPath("keystore.jceks")
-        .setPassword("secret"));
+        .setPassword("secret")
+        .setType("jceks"));
 
     JWTAuth provider = JWTAuth.create(vertx, config);
 


### PR DESCRIPTION
Motivation:

Fixes obscure `java.io.IOException: DerInputStream.getLength(): lengthTag=78, too big.` that happens when `setType` is omitted. Took me some time to find this but the unit tests set the type as well. Only the examples / docs omitted it.

Conformance:

I have updated my ECA. Applying the change to master since it only changes docs and is below 10 lines. Commit is signed.