### PR TITLE
Revert "Initial work, Authorizations are now CoW Immutable which should solve…"

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/AuthorizationProvider.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/AuthorizationProvider.java
@@ -16,7 +16,6 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.ext.auth.User;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -38,9 +37,7 @@ public interface AuthorizationProvider {
    * @return
    */
   static AuthorizationProvider create(String id, Set<Authorization> authorizations) {
-    Set<Authorization> _authorizations =
-      Collections.unmodifiableSet(new HashSet<>(Objects.requireNonNull(authorizations)));
-
+    Set<Authorization> _authorizations = new HashSet<>(Objects.requireNonNull(authorizations));
     return new AuthorizationProvider() {
 
       @Override
@@ -50,7 +47,7 @@ public interface AuthorizationProvider {
 
       @Override
       public Future<Void> getAuthorizations(User user) {
-        user.authorizations().put(getId(), _authorizations);
+        user.authorizations().add(getId(), _authorizations);
         return Future.succeededFuture();
       }
     };

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/Authorizations.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/Authorizations.java
@@ -13,96 +13,27 @@
 package io.vertx.ext.auth.authorization;
 
 import io.vertx.codegen.annotations.Fluent;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.codegen.annotations.VertxGen;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
-import static io.vertx.codegen.annotations.GenIgnore.PERMITTED_TYPE;
-
-/**
- * Represents a cache map of authorizations per provider.
- *
- * Authorizations are immutable and can be shared between users.
- *
- * @author Stephane Bastian
- */
 @VertxGen
 public interface Authorizations {
 
-  /**
-   * Replaces the current authorizations with the given authorizations.
-   * The map is expected to be immutable.
-   *
-   * @param authorizations the new map of authorizations.
-   * @return fluent self.
-   */
   @Fluent
-  @GenIgnore
-  Authorizations putAll(Map<String, Set<Authorization>> authorizations);
+  Authorizations add(String providerId, Set<Authorization> authorizations);
 
-  /**
-   * Replaces the current authorizations with the given authorizations for the given provider.
-   *
-   * @param providerId the provider.
-   * @param authorizations the new map of authorizations. {@code null} is equivalent to remove all authorizations for
-   *                      the given provider.
-   * @return fluent self.
-   */
   @Fluent
-  Authorizations put(String providerId, Set<Authorization> authorizations);
+  Authorizations add(String providerId, Authorization authorization);
 
-  /**
-   * Replaces the current authorizations with the given authorizations for the given provider.
-   *
-   * @param providerId the provider.
-   * @param authorizations the new array of authorizations.
-   * @return fluent self.
-   */
   @Fluent
-  @GenIgnore
-  default Authorizations put(String providerId, Authorization... authorizations) {
-    Set<Authorization> set = new HashSet<>();
-    Collections.addAll(set, authorizations);
-    return put(providerId, set);
-  }
+  Authorizations clear(String providerId);
 
-  /**
-   * {@code true} if the authorizations contains at least one provider.
-   */
-  boolean isEmpty();
-
-  /**
-   * Clears the authorizations.
-   */
   @Fluent
   Authorizations clear();
 
-  /**
-   * Verifies that the given authorization is present in the authorizations.
-   * @param resolvedAuthorization the authorization to verify.
-   * @return {@code true} if the authorization is present.
-   */
-  boolean verify(Authorization resolvedAuthorization);
+  Set<Authorization> get(String providerId);
 
-  /**
-   * Walk all the authorizations and call the consumer for each authorization.
-   * @param consumer the consumer to call.
-   */
-  @Fluent
-  @GenIgnore(PERMITTED_TYPE)
-  Authorizations forEach(BiConsumer<String, Authorization> consumer);
+  Set<String> getProviderIds();
 
-  /**
-   * Walk all the authorizations for the given provider and call the consumer for each authorization.
-   * @param consumer the consumer to call.
-   */
-  @Fluent
-  @GenIgnore(PERMITTED_TYPE)
-  Authorizations forEach(String providerId, Consumer<Authorization> consumer);
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/AuthorizationsImpl.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/AuthorizationsImpl.java
@@ -15,125 +15,94 @@ package io.vertx.ext.auth.authorization.impl;
 import io.vertx.ext.auth.authorization.Authorization;
 import io.vertx.ext.auth.authorization.Authorizations;
 
-import java.util.*;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class AuthorizationsImpl implements Authorizations {
 
-  private Map<String, Set<Authorization>> authorizations;
+  private final Map<String, Set<Authorization>> authorizations;
+
+  public AuthorizationsImpl() {
+    // store the authorizations as a concurrent hash map, mainly because this
+    // will be linked to a user object. In this case, we can't guarantee that
+    // concurrent access is safe.
+    this.authorizations = new ConcurrentHashMap<>();
+  }
 
   @Override
-  public synchronized Authorizations put(String providerId, Set<Authorization> _authorizations) {
+  public Authorizations add(String providerId, Authorization authorization) {
+    Objects.requireNonNull(authorization);
+    return add(providerId, Collections.singleton(authorization));
+  }
+
+  @Override
+  public Authorizations add(String providerId, Set<Authorization> authorizations) {
     Objects.requireNonNull(providerId);
-    Map<String, Set<Authorization>> authorizations = this.authorizations;
-    if (authorizations == null) {
-      if (_authorizations != null) {
-        authorizations = new HashMap<>();
-      }
-    } else {
-      authorizations = new HashMap<>(authorizations);
-      if (_authorizations == null) {
-        authorizations.remove(providerId);
-      }
-    }
-    if (_authorizations != null) {
-      authorizations
-        .put(providerId, Collections.unmodifiableSet(_authorizations));
-    }
-
-    // swap
-    this.authorizations = authorizations;
-    return this;
-  }
-
-  @Override
-  public synchronized Authorizations putAll(Map<String, Set<Authorization>> authorizations) {
     Objects.requireNonNull(authorizations);
-    this.authorizations = authorizations;
+
+    ConcurrentHashMap.KeySetView<Authorization, Boolean> concurrentAuthorizations = ConcurrentHashMap.newKeySet();
+    concurrentAuthorizations.addAll(authorizations);
+
+    getOrCreateAuthorizations(providerId)
+      .addAll(concurrentAuthorizations);
     return this;
   }
 
   @Override
-  public synchronized Authorizations clear() {
-    authorizations = null;
+  public Authorizations clear(String providerId) {
+    Objects.requireNonNull(providerId);
+
+    authorizations.remove(providerId);
     return this;
   }
 
   @Override
-  public boolean isEmpty() {
-    final Map<String, Set<Authorization>> authorizations = this.authorizations;
-    return authorizations == null || authorizations.isEmpty();
+  public Authorizations clear() {
+    authorizations.clear();
+    return this;
   }
 
   @Override
   public boolean equals(Object obj) {
-    final Map<String, Set<Authorization>> authorizations = this.authorizations;
-
     if (this == obj)
       return true;
     if (!(obj instanceof AuthorizationsImpl))
       return false;
     AuthorizationsImpl other = (AuthorizationsImpl) obj;
 
-    return Objects.equals(authorizations, other.authorizations);
+    return authorizations.equals(other.authorizations);
+  }
+
+  @Override
+  public Set<Authorization> get(String providerId) {
+    Objects.requireNonNull(providerId);
+
+    final Set<Authorization> set = authorizations.get(providerId);
+    if (set == null) {
+      return Collections.emptySet();
+    }
+
+    return set;
+  }
+
+  private Set<Authorization> getOrCreateAuthorizations(String providerId) {
+    return authorizations.computeIfAbsent(providerId, k -> ConcurrentHashMap.newKeySet());
+  }
+
+  @Override
+  public Set<String> getProviderIds() {
+    return authorizations.keySet();
   }
 
   @Override
   public int hashCode() {
-    final Map<String, Set<Authorization>> authorizations = this.authorizations;
-
     final int prime = 31;
     int result = 1;
-    result = prime * result + Objects.hashCode(authorizations);
+    result = prime * result + authorizations.hashCode();
     return result;
   }
 
-  @Override
-  public boolean verify(Authorization resolvedAuthorization) {
-    final Map<String, Set<Authorization>> authorizations = this.authorizations;
-
-    if (authorizations == null) {
-      return false;
-    }
-
-    for (Map.Entry<String, Set<Authorization>> kv : authorizations.entrySet()) {
-      for (Authorization authorization : kv.getValue()) {
-        if (authorization.verify(resolvedAuthorization)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  @Override
-  public Authorizations forEach(BiConsumer<String, Authorization> consumer) {
-    final Map<String, Set<Authorization>> authorizations = this.authorizations;
-
-    if (authorizations == null) {
-      return this;
-    }
-
-    for (Map.Entry<String, Set<Authorization>> kv : authorizations.entrySet()) {
-      for (Authorization authorization : kv.getValue()) {
-        consumer.accept(kv.getKey(), authorization);
-      }
-    }
-    return this;
-  }
-
-  @Override
-  public Authorizations forEach(String providerId, Consumer<Authorization> consumer) {
-    final Map<String, Set<Authorization>> authorizations = this.authorizations;
-
-    if (authorizations == null) {
-      return this;
-    }
-
-    authorizations
-      .getOrDefault(providerId, Collections.emptySet())
-      .forEach(consumer);
-    return this;
-  }
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/PermissionBasedAuthorizationImpl.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/PermissionBasedAuthorizationImpl.java
@@ -53,8 +53,14 @@ public class PermissionBasedAuthorizationImpl implements PermissionBasedAuthoriz
     User user = context.user();
     if (user != null) {
       final Authorization resolvedAuthorization = getResolvedAuthorization(context);
-      return user.authorizations()
-        .verify(resolvedAuthorization);
+      final Authorizations authorizations = user.authorizations();
+      for (String providerId : authorizations.getProviderIds()) {
+        for (Authorization authorization : authorizations.get(providerId)) {
+          if (authorization.verify(resolvedAuthorization)) {
+            return true;
+          }
+        }
+      }
     }
     return false;
   }
@@ -101,4 +107,5 @@ public class PermissionBasedAuthorizationImpl implements PermissionBasedAuthoriz
     this.resource = new VariableAwareExpression(resource);
     return this;
   }
+
 }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/RoleBasedAuthorizationImpl.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/RoleBasedAuthorizationImpl.java
@@ -55,8 +55,13 @@ public class RoleBasedAuthorizationImpl implements RoleBasedAuthorization {
     User user = context.user();
     if (user != null) {
       Authorization resolvedAuthorization = getResolvedAuthorization(context);
-      return user.authorizations()
-        .verify(resolvedAuthorization);
+      for (String providerId : user.authorizations().getProviderIds()) {
+        for (Authorization authorization : user.authorizations().get(providerId)) {
+          if (authorization.verify(resolvedAuthorization)) {
+            return true;
+          }
+        }
+      }
     }
     return false;
   }

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/WildcardPermissionBasedAuthorizationImpl.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/WildcardPermissionBasedAuthorizationImpl.java
@@ -58,8 +58,13 @@ public class WildcardPermissionBasedAuthorizationImpl implements WildcardPermiss
     User user = context.user();
     if (user != null) {
       Authorization resolvedAuthorization = getResolvedAuthorization(context);
-      return user.authorizations()
-        .verify(resolvedAuthorization);
+      for (String providerId : user.authorizations().getProviderIds()) {
+        for (Authorization authorization : user.authorizations().get(providerId)) {
+          if (authorization.verify(resolvedAuthorization)) {
+            return true;
+          }
+        }
+      }
     }
     return false;
   }

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/PermissionBasedAuthorizationTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/PermissionBasedAuthorizationTest.java
@@ -27,8 +27,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Collections;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -85,7 +83,7 @@ public class PermissionBasedAuthorizationTest {
     final HttpServer server = rule.vertx().createHttpServer();
     server.requestHandler(request -> {
       User user = User.fromName("dummy user");
-      user.authorizations().put("providerId", PermissionBasedAuthorization.create("p1").setResource("r1"));
+      user.authorizations().add("providerId", PermissionBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertEquals(true, PermissionBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();
@@ -105,7 +103,7 @@ public class PermissionBasedAuthorizationTest {
     final HttpServer server = rule.vertx().createHttpServer();
     server.requestHandler(request -> {
       User user = User.fromName("dummy user");
-      user.authorizations().put("providerId", PermissionBasedAuthorization.create("p1").setResource("r1"));
+      user.authorizations().add("providerId", PermissionBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertEquals(false, PermissionBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/RoleBasedAuthorizationTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/RoleBasedAuthorizationTest.java
@@ -26,8 +26,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Collections;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -78,7 +76,7 @@ public class RoleBasedAuthorizationTest {
     final HttpServer server = rule.vertx().createHttpServer();
     server.requestHandler(request -> {
       User user = User.fromName("dummy user");
-      user.authorizations().put("providerId", Collections.singleton(RoleBasedAuthorization.create("p1").setResource("r1")));
+      user.authorizations().add("providerId", RoleBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertTrue(RoleBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();
@@ -98,7 +96,7 @@ public class RoleBasedAuthorizationTest {
     final HttpServer server = rule.vertx().createHttpServer();
     server.requestHandler(request -> {
       User user = User.fromName("dummy user");
-      user.authorizations().put("providerId", Collections.singleton(RoleBasedAuthorization.create("p1").setResource("r1")));
+      user.authorizations().add("providerId", RoleBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertFalse(RoleBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/UserTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/UserTest.java
@@ -20,9 +20,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.*;
 
@@ -53,26 +50,23 @@ public class UserTest {
     // principal + authorizations
     User user = createTestUser();
     User.create(new JsonObject().put("name", "name1").put("value1", "a value"));
+    user.authorizations().add("providerId", PermissionBasedAuthorization.create("permission1"));
+    user.authorizations().add("providerId", RoleBasedAuthorization.create("role1"));
+    user.authorizations().add("providerId", WildcardPermissionBasedAuthorization.create("orders:edit:1234"));
+    user.authorizations().add("providerId", WildcardPermissionBasedAuthorization.create("billing:*"));
+    user.authorizations().add("providerId", NotAuthorization.create(PermissionBasedAuthorization.create("permission1")));
+    user.authorizations().add("providerId", AndAuthorization.create());
     user.authorizations()
-      .put(
-        "providerId",
-        PermissionBasedAuthorization.create("permission1"),
-        RoleBasedAuthorization.create("role1"),
-        WildcardPermissionBasedAuthorization.create("orders:edit:1234"),
-        WildcardPermissionBasedAuthorization.create("billing:*"),
-        NotAuthorization.create(PermissionBasedAuthorization.create("permission1")),
-        AndAuthorization.create(),
-        AndAuthorization.create()
-          .addAuthorization(PermissionBasedAuthorization.create("permission1"))
-          .addAuthorization(RoleBasedAuthorization.create("role1"))
-          .addAuthorization(PermissionBasedAuthorization.create("permission2"))
-          .addAuthorization(RoleBasedAuthorization.create("role2")),
-        OrAuthorization.create(),
-        OrAuthorization.create()
-          .addAuthorization(PermissionBasedAuthorization.create("permission1"))
-          .addAuthorization(RoleBasedAuthorization.create("role1"))
-          .addAuthorization(PermissionBasedAuthorization.create("permission2"))
-          .addAuthorization(RoleBasedAuthorization.create("role2")));
+      .add("providerId", AndAuthorization.create().addAuthorization(PermissionBasedAuthorization.create("permission1"))
+        .addAuthorization(RoleBasedAuthorization.create("role1"))
+        .addAuthorization(PermissionBasedAuthorization.create("permission2"))
+        .addAuthorization(RoleBasedAuthorization.create("role2")));
+    user.authorizations().add("providerId", OrAuthorization.create());
+    user.authorizations()
+      .add("providerId", OrAuthorization.create().addAuthorization(PermissionBasedAuthorization.create("permission1"))
+        .addAuthorization(RoleBasedAuthorization.create("role1"))
+        .addAuthorization(PermissionBasedAuthorization.create("permission2"))
+        .addAuthorization(RoleBasedAuthorization.create("role2")));
     testReadWriteUser(user);
   }
 
@@ -80,10 +74,8 @@ public class UserTest {
   public void testReadWriteUser3() {
     // principal + authorizations + attributes
     User user = createTestUser();
-    user.authorizations().put("providerId",
-      RoleBasedAuthorization.create("role1"),
-      RoleBasedAuthorization.create("role2"));
-
+    user.authorizations().add("providerId", RoleBasedAuthorization.create("role1"));
+    user.authorizations().add("providerId", RoleBasedAuthorization.create("role2"));
     testReadWriteUser(user);
   }
 
@@ -91,17 +83,11 @@ public class UserTest {
   public void testUniqueAuthorizations() {
     // principal + authorizations
     User user = createTestUser();
-    Set<Authorization> authorizations = new HashSet<>();
-
-    authorizations.add(PermissionBasedAuthorization.create("permission1"));
-    authorizations.add(PermissionBasedAuthorization.create("permission1"));
-    authorizations.add(RoleBasedAuthorization.create("role1"));
-    authorizations.add(RoleBasedAuthorization.create("role1"));
-
-    user.authorizations().put("providerId", authorizations);
-    final AtomicInteger cnt = new AtomicInteger();
-    user.authorizations().forEach("providerId", auth -> cnt.incrementAndGet());
-    Assert.assertEquals(2, cnt.get());
+    user.authorizations().add("providerId", PermissionBasedAuthorization.create("permission1"));
+    user.authorizations().add("providerId", PermissionBasedAuthorization.create("permission1"));
+    user.authorizations().add("providerId", RoleBasedAuthorization.create("role1"));
+    user.authorizations().add("providerId", RoleBasedAuthorization.create("role1"));
+    Assert.assertEquals(2, user.authorizations().get("providerId").size());
   }
 
   @Test

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/WildcardPermissionBasedAuthorizationTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/WildcardPermissionBasedAuthorizationTest.java
@@ -27,8 +27,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.Collections;
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -111,7 +109,7 @@ public class WildcardPermissionBasedAuthorizationTest {
     final HttpServer server = rule.vertx().createHttpServer();
     server.requestHandler(request -> {
       User user = User.fromName("dummy user");
-      user.authorizations().put("providerId", WildcardPermissionBasedAuthorization.create("p1").setResource("r1"));
+      user.authorizations().add("providerId", WildcardPermissionBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertTrue(WildcardPermissionBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();
@@ -130,7 +128,7 @@ public class WildcardPermissionBasedAuthorizationTest {
     final HttpServer server = rule.vertx().createHttpServer();
     server.requestHandler(request -> {
       User user = User.fromName("dummy user");
-      user.authorizations().put("providerId", WildcardPermissionBasedAuthorization.create("p1").setResource("r1"));
+      user.authorizations().add("providerId", WildcardPermissionBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertFalse(WildcardPermissionBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/authorization/impl/JWTAuthorizationImpl.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/authorization/impl/JWTAuthorizationImpl.java
@@ -73,7 +73,7 @@ public class JWTAuthorizationImpl implements JWTAuthorization {
         }
       }
     }
-    user.authorizations().put(getId(), authorizations);
+    user.authorizations().add(getId(), authorizations);
     // return
     return Future.succeededFuture();
   }

--- a/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/authorization/impl/MicroProfileAuthorizationImpl.java
+++ b/vertx-auth-jwt/src/main/java/io/vertx/ext/auth/jwt/authorization/impl/MicroProfileAuthorizationImpl.java
@@ -65,7 +65,7 @@ public class MicroProfileAuthorizationImpl implements MicroProfileAuthorization 
       }
     }
 
-    user.authorizations().put(getId(), authorizations);
+    user.authorizations().add(getId(), authorizations);
     // return
     return Future.succeededFuture();
   }

--- a/vertx-auth-jwt/src/test/java/io/vertx/ext/auth/test/jwt/MicroProfileTest.java
+++ b/vertx-auth-jwt/src/test/java/io/vertx/ext/auth/test/jwt/MicroProfileTest.java
@@ -103,7 +103,7 @@ public class MicroProfileTest {
     MicroProfileAuthorization.create().getAuthorizations(user)
       .onComplete(call -> {
         should.assertTrue(call.succeeded());
-        should.assertFalse(user.authorizations().isEmpty());
+        should.assertFalse(user.authorizations().getProviderIds().isEmpty());
         should.assertFalse(RoleBasedAuthorization.create("unknown").match(user));
         test.complete();
       });

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/KeycloakAuthorizationImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/KeycloakAuthorizationImpl.java
@@ -60,7 +60,7 @@ public class KeycloakAuthorizationImpl implements KeycloakAuthorization {
       return Future.failedFuture(e);
     }
 
-    user.authorizations().put(getId(), authorizations);
+    user.authorizations().add(getId(), authorizations);
     // return
     return Future.succeededFuture();
   }

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/ScopeAuthorizationImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/authorization/impl/ScopeAuthorizationImpl.java
@@ -49,19 +49,16 @@ public class ScopeAuthorizationImpl implements ScopeAuthorization {
         user.principal().getString("scope") :
         user.attributes().getJsonObject("accessToken", EMPTY).getString(claimKey);
 
-    final Set<Authorization> authorizations;
+    final Set<Authorization> authorizations = new HashSet<>();
 
     // avoid the case when scope is the literal "null" value.
     if (scopes != null) {
-      authorizations = new HashSet<>();
       String sep = user.attributes().getString("scope_separator", scopeSeparator);
       for (String scope : scopes.split(Pattern.quote(sep))) {
         authorizations.add(PermissionBasedAuthorization.create(scope));
       }
-    } else {
-      authorizations = Collections.emptySet();
     }
-    user.authorizations().put(getId(), authorizations);
+    user.authorizations().add(getId(), authorizations);
     // return
     return Future.succeededFuture();
   }

--- a/vertx-auth-properties/src/main/java/io/vertx/ext/auth/properties/impl/PropertyFileAuthenticationImpl.java
+++ b/vertx-auth-properties/src/main/java/io/vertx/ext/auth/properties/impl/PropertyFileAuthenticationImpl.java
@@ -189,7 +189,7 @@ public class PropertyFileAuthenticationImpl implements PropertyFileAuthenticatio
             result.add(WildcardPermissionBasedAuthorization.create(permission));
           }
         }
-        user.authorizations().put(getId(), result);
+        user.authorizations().add(getId(), result);
       })
       .mapEmpty();
   }

--- a/vertx-auth-sql-client/src/main/java/io/vertx/ext/auth/sqlclient/impl/SqlAuthorizationImpl.java
+++ b/vertx-auth-sql-client/src/main/java/io/vertx/ext/auth/sqlclient/impl/SqlAuthorizationImpl.java
@@ -75,7 +75,7 @@ public class SqlAuthorizationImpl implements SqlAuthorization {
           return getPermissions(username)
             .onSuccess(permissions -> {
               authorizations.addAll(permissions);
-              user.authorizations().put(getId(), authorizations);
+              user.authorizations().add(getId(), authorizations);
             })
             .mapEmpty();
         });


### PR DESCRIPTION
This breaks vertx-web - this is reverted until it is completely deployed across the stack

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project vertx-web: Compilation failure
[ERROR] /Users/julien/java/vertx-aggregator/modules/vertx-web/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/AuthorizationHandlerImpl.java:[120,33] cannot find symbol
[ERROR]   symbol:   method getProviderIds()
[ERROR]   location: interface io.vertx.ext.auth.authorization.Authorizations
[ERROR] 
[ERROR] -> [Help 1]
```