### PR TITLE
Added support for revoking KeyCloak tokens

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/KeycloakAuth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/KeycloakAuth.java
@@ -92,7 +92,7 @@ public interface KeycloakAuth extends OpenIDConnectAuth {
 
       options.setAuthorizationPath("/realms/" + realm + "/protocol/openid-connect/auth");
       options.setTokenPath("/realms/" + realm + "/protocol/openid-connect/token");
-      options.setRevocationPath(null);
+      options.setRevocationPath("/realms/" + realm + "/protocol/openid-connect/revoke");
       options.setLogoutPath("/realms/" + realm + "/protocol/openid-connect/logout");
       options.setUserInfoPath("/realms/" + realm + "/protocol/openid-connect/userinfo");
       // keycloak follows the RFC7662


### PR DESCRIPTION
## Changes
The revocation endpoint was forced to be null, when using the keycloak oauth2 provider. 

As per the keycloak documentation, there is an endpoint for revoking tokens: https://www.keycloak.org/docs/latest/securing_apps/#_token_revocation_endpoint

This would enable logging users out with API instead of redirects with keycloak.

## Motivation:

I need to be able to log out users, when using the keycloak OAuth2 provider.

This is currently not possible as the ``revoke`` method requires the ``revocationUrl != null``  and the ``logout`` method in ``OAuth2API`` is not accessible from outside the ``OAuth2Auth`` object.

This simple change allows users to use the flow described in the current vertx.io documentation for token management: https://vertx.io/docs/vertx-auth-oauth2/java/#_token_management

## Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
