### PR TITLE
NPE thrown if passwordProtection map does not contain an entry for the given alias

### DIFF
--- a/vertx-auth-jwt/src/test/java/io/vertx/ext/auth/test/jwt/JWTAuthProviderTest.java
+++ b/vertx-auth-jwt/src/test/java/io/vertx/ext/auth/test/jwt/JWTAuthProviderTest.java
@@ -68,6 +68,26 @@ public class JWTAuthProviderTest {
   }
 
   @Test
+  public void testCreateWithoutFailureWhenAliasIsNotSupported() {
+    JWTAuthOptions config = getConfig();
+    config
+      .getKeyStore()
+      .putPasswordProtection("foo", "not-so-secret");
+    JWTAuth.create(rule.vertx(), config);
+    // Just verify no exception is thrown
+  }
+
+  @Test
+  public void testCreateWithoutFailureWhenAliasDoesNotExist() {
+    JWTAuthOptions config = getConfig();
+    config
+      .getKeyStore()
+      .putPasswordProtection("HS384", "not-so-secret");
+    JWTAuth.create(rule.vertx(), config);
+    // Just verify no exception is thrown
+  }
+
+  @Test
   public void testValidJWT(TestContext should) {
     final Async test = should.async();
 


### PR DESCRIPTION
See #667

If the map does not contain an entry for the given alias, default to the keystore password.