### PR TITLE
Add Hybrid transport support

### DIFF
--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/AuthenticatorTransport.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/AuthenticatorTransport.java
@@ -28,6 +28,7 @@ public enum AuthenticatorTransport {
   USB("usb"),
   NFC("nfc"),
   BLE("ble"),
+  HYBRID("hybrid"),
   INTERNAL("internal");
 
 

--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/WebAuthnOptions.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/WebAuthnOptions.java
@@ -236,6 +236,7 @@ public class WebAuthnOptions {
     addTransport(USB);
     addTransport(NFC);
     addTransport(BLE);
+    addTransport(HYBRID);
     addTransport(INTERNAL);
     // default root certificates
     try {


### PR DESCRIPTION
Add support for "hybrid" authenticator transport (W3C Spec: https://github.com/w3c/webauthn/pull/1755)

"hybrid" transport is needed to use smartphones as a security key for client platforms like PC.

Addresses #665