### PR TITLE
Fix some copy constructors (#677)

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/JWTOptions.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/JWTOptions.java
@@ -5,19 +5,16 @@ import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @DataObject
 @JsonGen(publicConverter = false)
 public class JWTOptions {
 
-  private static final JsonObject EMPTY = new JsonObject(Collections.emptyMap());
-
   private int leeway = 0;
   private boolean ignoreExpiration;
   private String algorithm = "HS256";
-  private JsonObject header = EMPTY;
+  private JsonObject header;
   private boolean noTimestamp;
   private int expires;
   private List<String> audience;
@@ -27,23 +24,25 @@ public class JWTOptions {
   private String nonceAlgorithm;
 
   public JWTOptions() {
+    header = new JsonObject();
   }
 
   public JWTOptions(JWTOptions other) {
     this.leeway = other.leeway;
     this.ignoreExpiration = other.ignoreExpiration;
     this.algorithm = other.algorithm;
-    this.header = other.header;
+    this.header = other.header == null ? new JsonObject() : other.header.copy();
     this.noTimestamp = other.noTimestamp;
     this.expires = other.expires;
-    this.audience = other.audience;
+    this.audience = other.audience == null ? null : new ArrayList<>(other.audience);
     this.issuer = other.issuer;
     this.subject = other.subject;
-    this.permissions = other.permissions;
+    this.permissions = other.permissions == null ? null : new ArrayList<>(other.permissions);
     this.nonceAlgorithm = other.nonceAlgorithm;
   }
 
   public JWTOptions(JsonObject json) {
+    header = new JsonObject();
     JWTOptionsConverter.fromJson(json, this);
   }
 

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
@@ -36,8 +36,8 @@ public class PubSecKeyOptions {
    * @param other the options to copy
    */
   public PubSecKeyOptions(PubSecKeyOptions other) {
-    algorithm = other.getAlgorithm();
-    buffer = other.getBuffer();
+    algorithm = other.algorithm;
+    buffer = other.buffer == null ? null : other.buffer.copy();
     id = other.getId();
     publicKey = other.getPublicKey();
     secretKey = other.getSecretKey();

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/OAuth2Options.java
@@ -24,8 +24,8 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.PubSecKeyOptions;
 import io.vertx.ext.auth.JWTOptions;
+import io.vertx.ext.auth.PubSecKeyOptions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +49,6 @@ public class OAuth2Options {
   private static final String AUTHORIZATION_PATH = "/oauth/authorize";
   private static final String TOKEN_PATH = "/oauth/token";
   private static final String REVOCATION_PATH = "/oauth/revoke";
-  private static final JWTOptions JWT_OPTIONS = new JWTOptions();
   private static final String SCOPE_SEPARATOR = " ";
   private static final boolean VALIDATE_ISSUER = true;
   //seconds of JWK's default age (-1 means no rotation)
@@ -123,35 +122,25 @@ public class OAuth2Options {
     introspectionPath = other.getIntrospectionPath();
     scopeSeparator = other.getScopeSeparator();
     site = other.getSite();
-    pubSecKeys = other.getPubSecKeys();
-    jwtOptions = other.getJWTOptions();
+    if (other.pubSecKeys == null) {
+      pubSecKeys = null;
+    } else {
+      List<PubSecKeyOptions> list = new ArrayList<>(other.pubSecKeys.size());
+      for (PubSecKeyOptions pubSecKey : other.pubSecKeys) {
+        list.add(new PubSecKeyOptions(pubSecKey));
+      }
+      pubSecKeys = list;
+    }
+    jwtOptions = other.jwtOptions == null ? null : new JWTOptions(other.jwtOptions);
     logoutPath = other.getLogoutPath();
-    // extras
-    final JsonObject obj = other.getExtraParameters();
-    if (obj != null) {
-      extraParams = obj.copy();
-    } else {
-      extraParams = null;
-    }
-    // user info params
-    final JsonObject obj2 = other.getUserInfoParameters();
-    if (obj2 != null) {
-      userInfoParams = obj2.copy();
-    } else {
-      userInfoParams = null;
-    }
-    // custom headers
-    final JsonObject obj3 = other.getHeaders();
-    if (obj3 != null) {
-      headers = obj3.copy();
-    } else {
-      headers = null;
-    }
+    extraParams = other.extraParams == null ? null : other.extraParams.copy();
+    userInfoParams = other.userInfoParams == null ? null : other.userInfoParams.copy();
+    headers = other.headers == null ? null : other.headers.copy();
     jwkPath = other.getJwkPath();
     jwkMaxAge = other.getJwkMaxAgeInSeconds();
-    httpClientOptions = other.getHttpClientOptions();
+    httpClientOptions = other.httpClientOptions == null ? null : new HttpClientOptions(other.httpClientOptions);
     userAgent = other.getUserAgent();
-    supportedGrantTypes = other.getSupportedGrantTypes();
+    supportedGrantTypes = other.supportedGrantTypes == null ? null : new ArrayList<>(other.supportedGrantTypes);
     // compute paths with variables, at this moment it is only relevant that
     // the paths and site are properly computed
     replaceVariables(false);
@@ -164,7 +153,7 @@ public class OAuth2Options {
     tokenPath = TOKEN_PATH;
     revocationPath = REVOCATION_PATH;
     scopeSeparator = SCOPE_SEPARATOR;
-    jwtOptions = JWT_OPTIONS;
+    jwtOptions = new JWTOptions();
     jwkMaxAge = JWK_DEFAULT_AGE;
   }
 


### PR DESCRIPTION
Fixes #676

The copy constructors of JWTOptions PubSecKeyOptions and OAuth2Options were copying by reference some of their data.

This is not the expected behavior of Vert.x options.