### PR TITLE
Fix the length of the curveID

### DIFF
--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/tpm/PubArea.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/tpm/PubArea.java
@@ -59,7 +59,7 @@ public class PubArea {
       scheme = pubBuffer.getUnsignedShort(pos);
       pos+=2;
       curveID = pubBuffer.getUnsignedShort(pos);
-      pos+=4;
+      pos+=2;
       kdf = pubBuffer.getUnsignedShort(pos);
       pos+=2;
     } else {


### PR DESCRIPTION
Fixes https://github.com/eclipse-vertx/vertx-auth/issues/684
According to TPM 2.0 documentation, curveID has length of 2 bytes. This causes problem with reading length of unique.
