### PR TITLE
Remove AAGUID check from NoneAttestation

### DIFF
--- a/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/NoneAttestation.java
+++ b/vertx-auth-webauthn/src/main/java/io/vertx/ext/auth/webauthn/impl/attestation/NoneAttestation.java
@@ -41,11 +41,6 @@ public class NoneAttestation implements Attestation {
 
   @Override
   public AttestationCertificates validate(WebAuthnOptions options, MetaData metadata, byte[] clientDataJSON, JsonObject attestation, AuthData authData) throws AttestationException {
-    // AAGUID must be null
-    if (!"00000000-0000-0000-0000-000000000000".equals(authData.getAaguidString())) {
-      throw new AttestationException("AAGUID is not 00000000-0000-0000-0000-000000000000!");
-    }
-
     // attStmt must be empty
     if (attestation.containsKey("attStmt") && attestation.getJsonObject("attStmt").size() > 0) {
       throw new AttestationException("attStmt is present!");

--- a/vertx-auth-webauthn/src/test/java/io/vertx/ext/auth/webauthn/impl/attestation/AttestationTest.java
+++ b/vertx-auth-webauthn/src/test/java/io/vertx/ext/auth/webauthn/impl/attestation/AttestationTest.java
@@ -1,10 +1,7 @@
 package io.vertx.ext.auth.webauthn.impl.attestation;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.webauthn.DummyStore;
-import io.vertx.ext.auth.webauthn.RelyingParty;
-import io.vertx.ext.auth.webauthn.WebAuthn;
-import io.vertx.ext.auth.webauthn.WebAuthnOptions;
+import io.vertx.ext.auth.webauthn.*;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;

--- a/vertx-auth-webauthn/src/test/java/io/vertx/ext/auth/webauthn/impl/attestation/AttestationTest.java
+++ b/vertx-auth-webauthn/src/test/java/io/vertx/ext/auth/webauthn/impl/attestation/AttestationTest.java
@@ -87,6 +87,37 @@ public class AttestationTest {
   }
 
   @Test
+  public void testNoneAttestationWithNonZeroAAGUID(TestContext should) {
+    final Async test = should.async();
+
+    WebAuthn webAuthN = WebAuthn.create(
+        rule.vertx(),
+        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("FIDO Examples Corporation")))
+      .authenticatorFetcher(database::fetch)
+      .authenticatorUpdater(database::store);
+
+    JsonObject packedFullAttestationWebAuthnSample = new JsonObject()
+      .put("rawId", "NXuPCPFpc9r3QrCL3dEQqg")
+      .put("id", "NXuPCPFpc9r3QrCL3dEQqg")
+      .put("type", "public-key")
+      .put("response", new JsonObject()
+        .put("clientDataJSON", "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoieW5CaVctWlhSdHVSTmF1OFgwRURMUSIsIm9yaWdpbiI6Imh0dHBzOlwvXC81NTlhLTEwNi0xMzktMTM4LTI0My5uZ3Jvay1mcmVlLmFwcCIsImFuZHJvaWRQYWNrYWdlTmFtZSI6ImNvbS5hbmRyb2lkLmNocm9tZSJ9")
+        .put("attestationObject", "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YViUHT97vfV9fOzGz3r17kQoRd6881wS7VK-SXENe6WwxcddAAAAAOqbjWZNAR0hPOS2tIy1ddQAEDV7jwjxaXPa90Kwi93REKqlAQIDJiABIVggRjiIjY-sUTXhqNi5z2Pm9irTUvJnYC865BJytjXBDdsiWCD2BScW511sKkQ28ztKs_DKTVRMcYINMRMR8lwT958G8g"));
+
+    webAuthN.authenticate(
+        new WebAuthnCredentials()
+          .setUsername("paulo")
+          .setOrigin("https://559a-106-139-138-243.ngrok-free.app")
+          .setWebauthn(packedFullAttestationWebAuthnSample)
+          .setChallenge("ynBiW-ZXRtuRNau8X0EDLQ"))
+      .onFailure(should::fail)
+      .onSuccess(user -> {
+        should.assertNotNull(user);
+        test.complete();
+      });
+  }
+
+  @Test
   public void testU2FAttestation(TestContext should) {
     final Async test = should.async();
 


### PR DESCRIPTION
because it is not required by WebAuthn specification and FIDO
conformance tool. Also, this check blocks Apple's passkey and Google
Password Manager's passkey.

Backported from #671 