### PR TITLE
Rename from PublicKeyCredential to COSEAlgorithm

### DIFF
--- a/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/AttestationCertificatesConverter.java
+++ b/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/AttestationCertificatesConverter.java
@@ -2,8 +2,6 @@ package io.vertx.ext.auth.webauthn4j;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.ext.auth.webauthn4j.AttestationCertificates}.
@@ -16,7 +14,7 @@ public class AttestationCertificatesConverter {
       switch (member.getKey()) {
         case "alg":
           if (member.getValue() instanceof String) {
-            obj.setAlg(io.vertx.ext.auth.webauthn4j.PublicKeyCredential.valueOf((String)member.getValue()));
+            obj.setAlg(COSEAlgorithm.valueOf((String)member.getValue()));
           }
           break;
         case "x5c":

--- a/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/WebAuthn4JOptionsConverter.java
+++ b/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/WebAuthn4JOptionsConverter.java
@@ -2,8 +2,6 @@ package io.vertx.ext.auth.webauthn4j;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
-import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.ext.auth.webauthn4j.WebAuthn4JOptions}.
@@ -41,10 +39,10 @@ public class WebAuthn4JOptionsConverter {
           break;
         case "pubKeyCredParams":
           if (member.getValue() instanceof JsonArray) {
-            java.util.ArrayList<io.vertx.ext.auth.webauthn4j.PublicKeyCredential> list =  new java.util.ArrayList<>();
+            java.util.ArrayList<COSEAlgorithm> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(io.vertx.ext.auth.webauthn4j.PublicKeyCredential.valueOf((String)item));
+                list.add(COSEAlgorithm.valueOf((String)item));
             });
             obj.setPubKeyCredParams(list);
           }

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/AttestationCertificates.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/AttestationCertificates.java
@@ -33,7 +33,7 @@ public class AttestationCertificates {
   /**
    * The algorithm used for the public credential
    */
-  private PublicKeyCredential alg;
+  private COSEAlgorithm alg;
 
   /**
    * The list of X509 certificates encoded as base64url.
@@ -47,11 +47,11 @@ public class AttestationCertificates {
     AttestationCertificatesConverter.fromJson(json, this);
   }
 
-  public PublicKeyCredential getAlg() {
+  public COSEAlgorithm getAlg() {
     return alg;
   }
 
-  public AttestationCertificates setAlg(PublicKeyCredential alg) {
+  public AttestationCertificates setAlg(COSEAlgorithm alg) {
     this.alg = alg;
     return this;
   }

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/COSEAlgorithm.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/COSEAlgorithm.java
@@ -22,7 +22,7 @@ import io.vertx.codegen.annotations.VertxGen;
  * https://www.iana.org/assignments/cose/cose.xhtml#algorithms
  */
 @VertxGen
-public enum PublicKeyCredential {
+public enum COSEAlgorithm {
   ES256(-7),
   ES384(-35),
   ES512(-36),
@@ -38,11 +38,11 @@ public enum PublicKeyCredential {
 
   private final int coseId;
 
-  PublicKeyCredential(int coseId) {
+  COSEAlgorithm(int coseId) {
     this.coseId = coseId;
   }
 
-  public static PublicKeyCredential valueOf(int coseId) {
+  public static COSEAlgorithm valueOf(int coseId) {
     switch (coseId) {
       case -7:
         return ES256;

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/WebAuthn4JOptions.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/WebAuthn4JOptions.java
@@ -28,13 +28,11 @@ import io.vertx.ext.auth.impl.jose.JWS;
 
 import static io.vertx.ext.auth.webauthn4j.Attestation.NONE;
 import static io.vertx.ext.auth.webauthn4j.AuthenticatorTransport.*;
-import static io.vertx.ext.auth.webauthn4j.PublicKeyCredential.ES256;
-import static io.vertx.ext.auth.webauthn4j.PublicKeyCredential.RS256;
+import static io.vertx.ext.auth.webauthn4j.COSEAlgorithm.ES256;
+import static io.vertx.ext.auth.webauthn4j.COSEAlgorithm.RS256;
 import static io.vertx.ext.auth.webauthn4j.UserVerification.DISCOURAGED;
 
-import java.security.cert.CRLException;
 import java.security.cert.CertificateException;
-import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.*;
 
@@ -200,7 +198,7 @@ public class WebAuthn4JOptions {
   private Attestation attestation;
 
   // Needs to be a list, order is important
-  private List<PublicKeyCredential> pubKeyCredParams;
+  private List<COSEAlgorithm> pubKeyCredParams;
 
   private int challengeLength;
   private JsonObject extensions;
@@ -210,7 +208,7 @@ public class WebAuthn4JOptions {
 //  private List<X509CRL> rootCrls;
 
   private boolean relaxedSafetyNetIntegrityVeridict;
-  
+
   private boolean useMetadata;
 
   private boolean userPresenceRequired;
@@ -327,11 +325,11 @@ public class WebAuthn4JOptions {
     return this;
   }
 
-  public List<PublicKeyCredential> getPubKeyCredParams() {
+  public List<COSEAlgorithm> getPubKeyCredParams() {
     return pubKeyCredParams;
   }
 
-  public WebAuthn4JOptions addPubKeyCredParam(PublicKeyCredential pubKeyCredParam) {
+  public WebAuthn4JOptions addPubKeyCredParam(COSEAlgorithm pubKeyCredParam) {
     if (pubKeyCredParam == null) {
       throw new IllegalArgumentException("pubKeyCredParam cannot be null");
     }
@@ -345,7 +343,7 @@ public class WebAuthn4JOptions {
     return this;
   }
 
-  public WebAuthn4JOptions setPubKeyCredParams(List<PublicKeyCredential> pubKeyCredParams) {
+  public WebAuthn4JOptions setPubKeyCredParams(List<COSEAlgorithm> pubKeyCredParams) {
     if (pubKeyCredParams.size() == 0) {
       throw new IllegalArgumentException("PubKeyCredParams must have at least 1 element");
     }
@@ -540,11 +538,11 @@ public class WebAuthn4JOptions {
     this.useMetadata = useMetadata;
     return this;
   }
-  
+
   public boolean isUseMetadata() {
     return useMetadata;
   }
-  
+
   public JsonObject toJson() {
     final JsonObject json = new JsonObject();
     WebAuthn4JOptionsConverter.toJson(this, json);
@@ -559,7 +557,7 @@ public class WebAuthn4JOptions {
   public boolean isUserPresenceRequired() {
     return userPresenceRequired;
   }
-  
+
   public WebAuthn4JOptions setUserPresenceRequired(boolean userPresenceRequired) {
     this.userPresenceRequired = userPresenceRequired;
     return this;

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/impl/WebAuthn4JImpl.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/impl/WebAuthn4JImpl.java
@@ -98,18 +98,8 @@ import io.vertx.ext.auth.authentication.Credentials;
 import io.vertx.ext.auth.impl.CertificateHelper;
 import io.vertx.ext.auth.impl.CertificateHelper.CertInfo;
 import io.vertx.ext.auth.prng.VertxContextPRNG;
-import io.vertx.ext.auth.webauthn4j.Attestation;
-import io.vertx.ext.auth.webauthn4j.AttestationCertificates;
-import io.vertx.ext.auth.webauthn4j.Authenticator;
-import io.vertx.ext.auth.webauthn4j.AuthenticatorTransport;
-import io.vertx.ext.auth.webauthn4j.CredentialStorage;
-import io.vertx.ext.auth.webauthn4j.PublicKeyCredential;
-import io.vertx.ext.auth.webauthn4j.ResidentKey;
-import io.vertx.ext.auth.webauthn4j.UserVerification;
-import io.vertx.ext.auth.webauthn4j.WebAuthn4J;
-import io.vertx.ext.auth.webauthn4j.WebAuthn4JOptions;
-import io.vertx.ext.auth.webauthn4j.WebAuthn4JCredentials;
-import io.vertx.ext.auth.webauthn4j.WebAuthn4JException;
+import io.vertx.ext.auth.webauthn4j.*;
+import io.vertx.ext.auth.webauthn4j.COSEAlgorithm;
 
 public class WebAuthn4JImpl implements WebAuthn4J {
 
@@ -269,7 +259,7 @@ public class WebAuthn4JImpl implements WebAuthn4J {
         putOpt(json.getJsonObject("user"), "displayName", user.getString("displayName"));
         putOpt(json.getJsonObject("user"), "icon", user.getString("icon"));
         // put the public key credentials parameters
-        for (PublicKeyCredential pubKeyCredParam : options.getPubKeyCredParams()) {
+        for (COSEAlgorithm pubKeyCredParam : options.getPubKeyCredParams()) {
           addOpt(
             json.getJsonArray("pubKeyCredParams"),
             new JsonObject()
@@ -552,8 +542,8 @@ public class WebAuthn4JImpl implements WebAuthn4J {
 	  boolean userPresenceRequired = options.isUserPresenceRequired();
 
 	  List<PublicKeyCredentialParameters> pubKeyCredParams = new ArrayList<>(options.getPubKeyCredParams().size());
-	  for (PublicKeyCredential publicKeyCredential : options.getPubKeyCredParams()) {
-      pubKeyCredParams.add(new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.create(publicKeyCredential.coseId())));
+	  for (COSEAlgorithm COSEAlgorithm : options.getPubKeyCredParams()) {
+      pubKeyCredParams.add(new PublicKeyCredentialParameters(PublicKeyCredentialType.PUBLIC_KEY, COSEAlgorithmIdentifier.create(COSEAlgorithm.coseId())));
     }
 	  RegistrationParameters registrationParameters = new RegistrationParameters(serverProperty, pubKeyCredParams, userVerificationRequired, userPresenceRequired);
 
@@ -588,20 +578,20 @@ public class WebAuthn4JImpl implements WebAuthn4J {
       }
       // algo
       if(attestationStatement instanceof AndroidKeyAttestationStatement){
-        attestationCertificates.setAlg(PublicKeyCredential.valueOf((int) ((AndroidKeyAttestationStatement)attestationStatement).getAlg().getValue()));
+        attestationCertificates.setAlg(COSEAlgorithm.valueOf((int) ((AndroidKeyAttestationStatement)attestationStatement).getAlg().getValue()));
       } else if(attestationStatement instanceof AndroidSafetyNetAttestationStatement){
         // hoping the names match
-        attestationCertificates.setAlg(PublicKeyCredential.valueOf(((AndroidSafetyNetAttestationStatement)attestationStatement).getResponse().getHeader().getAlg().getName()));
+        attestationCertificates.setAlg(COSEAlgorithm.valueOf(((AndroidSafetyNetAttestationStatement)attestationStatement).getResponse().getHeader().getAlg().getName()));
       } else if(attestationStatement instanceof AppleAnonymousAttestationStatement){
         // FIXME: optional, but not read in webauthn4j?
         attestationCertificates.setAlg(null);
       } else if(attestationStatement instanceof FIDOU2FAttestationStatement){
         // seems to be fixed?
-        attestationCertificates.setAlg(PublicKeyCredential.valueOf((int) COSEAlgorithmIdentifier.ES256.getValue()));
+        attestationCertificates.setAlg(COSEAlgorithm.valueOf((int) COSEAlgorithmIdentifier.ES256.getValue()));
       } else if(attestationStatement instanceof PackedAttestationStatement){
-        attestationCertificates.setAlg(PublicKeyCredential.valueOf((int) ((PackedAttestationStatement)attestationStatement).getAlg().getValue()));
+        attestationCertificates.setAlg(COSEAlgorithm.valueOf((int) ((PackedAttestationStatement)attestationStatement).getAlg().getValue()));
       } else if(attestationStatement instanceof TPMAttestationStatement){
-        attestationCertificates.setAlg(PublicKeyCredential.valueOf((int) ((TPMAttestationStatement)attestationStatement).getAlg().getValue()));
+        attestationCertificates.setAlg(COSEAlgorithm.valueOf((int) ((TPMAttestationStatement)attestationStatement).getAlg().getValue()));
       } else {
         throw new WebAuthn4JException("Unsupported attestation statement format: "+attestationStatement.getFormat());
       }

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/WebAuth4JNTest.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/WebAuth4JNTest.java
@@ -3,6 +3,7 @@ package io.vertx.tests;
 import java.security.cert.CertificateException;
 import java.util.Base64;
 
+import io.vertx.ext.auth.webauthn4j.*;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -11,12 +12,7 @@ import org.junit.runner.RunWith;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.impl.jose.JWS;
-import io.vertx.ext.auth.webauthn4j.Authenticator;
-import io.vertx.ext.auth.webauthn4j.PublicKeyCredential;
-import io.vertx.ext.auth.webauthn4j.RelyingParty;
-import io.vertx.ext.auth.webauthn4j.WebAuthn4J;
-import io.vertx.ext.auth.webauthn4j.WebAuthn4JOptions;
-import io.vertx.ext.auth.webauthn4j.WebAuthn4JCredentials;
+import io.vertx.ext.auth.webauthn4j.COSEAlgorithm;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
@@ -120,7 +116,7 @@ public class WebAuth4JNTest {
     WebAuthn4J webAuthN = WebAuthn4J.create(
         rule.vertx(),
         new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("FIDO Examples Corporation"))
-        .addPubKeyCredParam(PublicKeyCredential.RS1)
+        .addPubKeyCredParam(COSEAlgorithm.RS1)
         )
         .credentialStorage(database);
 

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/attestation/AttestationTest.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/attestation/AttestationTest.java
@@ -9,8 +9,6 @@ import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.tests.DummyStore;
 
-import static io.vertx.ext.auth.webauthn4j.PublicKeyCredential.RS256;
-
 import java.security.cert.CertificateException;
 
 import org.junit.Before;
@@ -586,7 +584,7 @@ public class AttestationTest {
         rule.vertx(),
         new WebAuthn4JOptions()
         .setRelyingParty(new RelyingParty().setName("FIDO Examples Corporation"))
-        .addPubKeyCredParam(PublicKeyCredential.RS1)
+        .addPubKeyCredParam(COSEAlgorithm.RS1)
         )
         .credentialStorage(database);
 


### PR DESCRIPTION
Addresses #699

Motivation:

since WebAuthn specification uses the name "PublicKeyCredential" for [other type](https://w3c.github.io/webauthn/#publickeycredential).
