### PR TITLE
Updated docs for webauth/webauthn4j about storage

### DIFF
--- a/vertx-auth-webauthn/src/main/asciidoc/index.adoc
+++ b/vertx-auth-webauthn/src/main/asciidoc/index.adoc
@@ -128,6 +128,34 @@ This provides a root of trust for a newly generated key pair as well as being ab
 It should be noted that while attestation provides the capability for a root of trust, validating the root of trust is frequently not necessary.
 When registering an authenticator for a new account, typically a Trust On First Use (TOFU) model applies; and when adding an authenticator to an existing account, a user has already been authenticated and has established a secure session.
 
+== Security considerations
+
+=== Registration
+
+During registration, your `WebAuthn.authenticatorUpdater` function will be called with a new authenticator to store. You can recognise that
+it should be stored because you should not have any existing authenticator stored with the same `credID`, which are unique.
+
+Because users are identified using a unique _UserName_, you must make sure to refuse storing a new authenticator for a _UserName_ which already has
+stored authenticators, unless the user is already currently logged in with the same _UserName_. Otherwise you would be letting new untrusted users
+add their own authenticators to existing unrelated users, allowing them to hijack accounts trivially.
+
+Vert.x's `WebAuthn.authenticate` will not invoke your `WebAuthn.authenticatorFetcher` to verify whether you already have authenticators
+for the given _UserName_ or not. This is up to your code to implement this check in `WebAuthn.authenticatorUpdater` to return a _failed Future_
+when you don't want to store a new authenticator to an existing user.
+
+Naturally, if the user is already logged in, using the same _UserName_, you can allow that user to store new authenticators, all of which will
+allow this user to log in.
+
+=== Login
+
+During login, your `WebAuthn.authenticatorUpdater` function will be called with an existing authenticator. You can recognise that it should
+be updated (as opposed to stored) because you should have an existing authenticator stored with the same `credID`, which are unique. 
+
+In this case, all you have to do is save the `counter` to the already stored authenticator.
+
+You can trust this authenticator update because `WebAuthn.authenticate` will have called your `WebAuthn.authenticatorFetcher` with the
+looked up `credID` and verify that the signatures match.
+
 == A simple example
 
 === Create a Registration request
@@ -143,6 +171,8 @@ When registering an authenticator for a new account, typically a Trust On First 
 ----
 {@link examples.WebAuthNExamples#example2}
 ----
+
+Warning: See <<Security considerations>>
 
 === Create a Login request
 

--- a/vertx-auth-webauthn/src/test/java/io/vertx/tests/NavigatorCredentialsCreateTest.java
+++ b/vertx-auth-webauthn/src/test/java/io/vertx/tests/NavigatorCredentialsCreateTest.java
@@ -1,7 +1,7 @@
 package io.vertx.tests;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.webauthn4j.*;
+import io.vertx.ext.auth.webauthn.*;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(VertxUnitRunner.class)
-public class NavigatorCredentialsCreate {
+public class NavigatorCredentialsCreateTest {
 
   private final DummyStore database = new DummyStore();
 
@@ -30,11 +30,12 @@ public class NavigatorCredentialsCreate {
   public void testRequestRegister(TestContext should) {
     final Async test = should.async();
 
-    WebAuthn4J webAuthN = WebAuthn4J.create(
+    WebAuthn webAuthN = WebAuthn.create(
         rule.vertx(),
-        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation"))
+        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation"))
           .setAttestation(Attestation.of("direct")))
-        .credentialStorage(database);
+      .authenticatorFetcher(database::fetch)
+      .authenticatorUpdater(database::store);
 
     // Dummy user
     JsonObject user = new JsonObject()
@@ -65,10 +66,53 @@ public class NavigatorCredentialsCreate {
   public void testRegister(TestContext should) {
     final Async test = should.async();
 
-    WebAuthn4J webAuthN = WebAuthn4J.create(
+    WebAuthn webAuthN = WebAuthn.create(
         rule.vertx(),
-        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
-        .credentialStorage(database);
+        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
+      .authenticatorFetcher(database::fetch)
+      .authenticatorUpdater(database::store);
+
+    // dummy request
+    JsonObject request = new JsonObject()
+      .put("id", "Q-MHP0Xq20CKM5LW3qBt9gu5vdOYLNZc3jCcgyyLncRav5Ivd7T1dav3eWrI7CT8HmzU_yAYJrmja4in8OFL3ASTEF")
+      .put("rawId", "Q-MHP0Xq20CKM5LW3qBt9gu5vdOYLNZc3jCcgyyLncRav5Ivd7T1dav3eWrI7CT8HmzU_yAYJrmja4in8OFL3ASTEF")
+      .put("type", "public-key")
+      .put("response", new JsonObject()
+        .put("attestationObject", "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEfxV8VVBPmz66RLzscHpg5yjRhO28Y_fPwYO5AVwzBEJBAAAAAwAAAAAAAAAAAAAAAAAAAAAAQEPjBz9F6ttAijOS1t6gbfYLub3TmCzWXN4wnIMsi53EWr-SL3e09XWr93lqyOwk_B5s1P8gGCa5o2uIp_DhS9ylAQIDJiABIVggN_D3u-03a0GzONOHfaML881QZtOCc5oTNRB2wlyqUEUiWCD3878XoO_bIJf0mEPDILODFhVmkc4QeR6hOIDvwvXzYQ")
+        .put("clientDataJSON", "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiQkg3RUtJRFhVNkN0Xzk2eFR6RzBsNjJxTWhXX0VmX0s0TVFkRExvVk5jMVVYTVFZNHFOOWFnNXlETm1MSTd2RlJzbGtRYmJqMEpaV0p4R1ZmTXVnWGciLCJvcmlnaW4iOiJodHRwczovLzE5Mi4xNjguMTc4LjIwNi54aXAuaW86ODQ0MyIsImNyb3NzT3JpZ2luIjpmYWxzZX0"));
+
+    webAuthN
+      .authenticate(
+        new WebAuthnCredentials()
+          .setUsername("paulo")
+          .setOrigin("https://192.168.178.206.xip.io:8443")
+          .setDomain("192.168.178.206.xip.io")
+          .setChallenge("BH7EKIDXU6Ct_96xTzG0l62qMhW_Ef_K4MQdDLoVNc1UXMQY4qN9ag5yDNmLI7vFRslkQbbj0JZWJxGVfMugXg")
+          .setWebauthn(request))
+      .onFailure(should::fail)
+      .onSuccess(response -> {
+        assertNotNull(response);
+        test.complete();
+      });
+  }
+  
+  @Test
+  public void testRegisterExistingUser(TestContext should) {
+    final Async test = should.async();
+
+    WebAuthn webAuthN = WebAuthn.create(
+        rule.vertx(),
+        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
+      .authenticatorFetcher(database::fetch)
+      .authenticatorUpdater(database::store);
+
+    database.add(
+        new Authenticator()
+          .setUserName("paulo")
+          .setCredID("O3ZJlAdXvra6PwvL4I9AP99dS1_v3DDRuB_SwTAHFbUfMtvWTOFycCeb6CkXZXiPWi9Nr0ptUnlnHP3U40ptEA")
+          .setPublicKey("pQECAyYgASFYIBl0C67nFN_OwbODu_iE0hI5nM0ppUkqjhU9NhQvBaiLIlggffUTx8E6OM85huU3DcadeuaBBh8kGI8vdm3zesf3YRc")
+          .setCounter(2)
+      );
 
     // dummy request
     JsonObject request = new JsonObject()
@@ -81,16 +125,16 @@ public class NavigatorCredentialsCreate {
 
     webAuthN
       .authenticate(
-        new WebAuthn4JCredentials()
+        new WebAuthnCredentials()
           .setUsername("paulo")
           .setOrigin("https://192.168.178.206.xip.io:8443")
           .setDomain("192.168.178.206.xip.io")
           .setChallenge("BH7EKIDXU6Ct_96xTzG0l62qMhW_Ef_K4MQdDLoVNc1UXMQY4qN9ag5yDNmLI7vFRslkQbbj0JZWJxGVfMugXg")
           .setWebauthn(request))
-      .onFailure(should::fail)
+      .onFailure(x -> test.complete())
       .onSuccess(response -> {
-        assertNotNull(response);
-        test.complete();
+        should.fail("We got logged in while another user already existed with the same user name");
       });
   }
+
 }

--- a/vertx-auth-webauthn/src/test/java/io/vertx/tests/NavigatorCredentialsGetTest.java
+++ b/vertx-auth-webauthn/src/test/java/io/vertx/tests/NavigatorCredentialsGetTest.java
@@ -1,7 +1,7 @@
 package io.vertx.tests;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.webauthn4j.*;
+import io.vertx.ext.auth.webauthn.*;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(VertxUnitRunner.class)
-public class NavigatorCredentialsGet {
+public class NavigatorCredentialsGetTest {
 
   private final DummyStore database = new DummyStore();
 
@@ -30,10 +30,11 @@ public class NavigatorCredentialsGet {
   public void testRequestLogin(TestContext should) {
     final Async test = should.async();
 
-    WebAuthn4J webAuthN = WebAuthn4J.create(
+    WebAuthn webAuthN = WebAuthn.create(
         rule.vertx(),
-        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
-        .credentialStorage(database);
+        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
+      .authenticatorFetcher(database::fetch)
+      .authenticatorUpdater(database::store);
 
     database.add(
       new Authenticator()
@@ -60,10 +61,11 @@ public class NavigatorCredentialsGet {
   public void testLoginRequestChallenge(TestContext should) {
     final Async test = should.async();
 
-    WebAuthn4J webAuthN = WebAuthn4J.create(
+    WebAuthn webAuthN = WebAuthn.create(
         rule.vertx(),
-        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
-        .credentialStorage(database);
+        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
+      .authenticatorFetcher(database::fetch)
+      .authenticatorUpdater(database::store);
 
     database.add(
       new Authenticator()
@@ -85,7 +87,7 @@ public class NavigatorCredentialsGet {
         .put("signature", "MEUCIFXjL0ONRuLP1hkdlRJ8d0ofuRAS12c6w8WgByr-0yQZAiEAw-C6UZ8U8pi8irAcD6jXXaZMtezbzVwZXLGqY3sbFyA")
         .put("userHandle", ""));
 
-    webAuthN.authenticate(new WebAuthn4JCredentials()
+    webAuthN.authenticate(new WebAuthnCredentials()
         .setWebauthn(body)
         .setUsername("paulo")
         .setOrigin("https://192.168.178.206.xip.io:8443")

--- a/vertx-auth-webauthn4j/src/main/asciidoc/index.adoc
+++ b/vertx-auth-webauthn4j/src/main/asciidoc/index.adoc
@@ -127,6 +127,34 @@ This provides a root of trust for a newly generated key pair as well as being ab
 It should be noted that while attestation provides the capability for a root of trust, validating the root of trust is frequently not necessary.
 When registering an authenticator for a new account, typically a Trust On First Use (TOFU) model applies; and when adding an authenticator to an existing account, a user has already been authenticated and has established a secure session.
 
+== Security considerations
+
+=== Registration
+
+During registration, your `CredentialStorage.storeCredential` method will be called with a new authenticator to store. 
+You should not have any existing authenticator already stored with the same `credID`, because they are unique.
+
+Because users are identified using a unique _UserName_, you must make sure to refuse storing a new authenticator for a _UserName_ which already has
+stored authenticators, unless the user is already currently logged in with the same _UserName_. Otherwise you would be letting new untrusted users
+add their own authenticators to existing unrelated users, allowing them to hijack accounts trivially.
+
+Vert.x's `WebAuthn.authenticate` will not invoke your `CredentialStorage.find` to verify whether you already have authenticators
+for the given _UserName_ or not. This is up to your code to implement this check in `CredentialStorage.storeCredential` to return a _failed Future_
+when you don't want to store a new authenticator to an existing user.
+
+Naturally, if the user is already logged in, using the same _UserName_, you can allow that user to store new authenticators, all of which will
+allow this user to log in.
+
+=== Login
+
+During login, your `CredentialStorage.updateCounter` method will be called with an existing authenticator. It should
+be updated (as opposed to stored) and you should have an existing authenticator already stored with the same unique `credID`. 
+
+In this case, all you have to do is save the `counter` to the already stored authenticator.
+
+You can trust this authenticator update because `WebAuthn.authenticate` will have called your `CredentialStorage.find` with the
+looked up `credID` and verify that the signatures match.
+
 == A simple example
 
 === Create a Registration request
@@ -142,6 +170,8 @@ When registering an authenticator for a new account, typically a Trust On First 
 ----
 {@link examples.WebAuthN4JExamples#example2}
 ----
+
+Warning: See <<Security considerations>>
 
 === Create a Login request
 

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/CredentialStorage.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/CredentialStorage.java
@@ -32,18 +32,30 @@ public interface CredentialStorage {
 
 	/**
 	 * Persists a new credential, bound by its user name (may be <code>null</code>) and credential ID
-	 * (cannot be <code>null</code>)
+	 * (cannot be <code>null</code>, must be unique).
+	 * 
+	 * If attempting to store a credential with a <code>credId</code> that is not unique, you should return
+	 * a failed <code>Future</code>.
+   * 
+   * If attempting to store a credential with a <code>userName</code> that already exists, you should 
+   * first make sure that the current user is already logged in under the same <code>userName</code>, because
+   * this will in practice add a new credential to identify the existing user, so this must be restricted
+   * to the already existing user, otherwise you will allow anyone to gain access to existing users.
+   * 
+   * If attempting to store a credential with a <code>userName</code> that already exists, and the current
+   * user is not logged in, or the logged in user does not have the same <code>userName</code>, you should
+   * return a failed <code>Future</code>.
+	 * 
 	 * @param authenticator the new credential to persist
-	 * @return a future of nothing
+	 * @return a future of nothing, or a failed future if the <code>credId</code> already exists, or if the
+	 * <code>userName</code> already exists and does not represent the currently logged in user.
 	 */
 	Future<Void> storeCredential(Authenticator authenticator);
 
   /**
-   * Updates a credential counter, as identified by its user name (may be <code>null</code>) and credential ID
-   * (cannot be <code>null</code>).
-   * @param userName the user name (may be <code>null</code>, but must match if specified)
-   * @param credentialId the credential ID (cannot be <code>null</code>, must match)
-   * @param counter the new counter to persist
+   * Updates a previously stored credential counter, as identified by its user name (may be <code>null</code>) and credential ID
+   * (cannot be <code>null</code>, must be unique).
+   * @param authenticator the credential to update
    * @return a future of nothing
    */
   Future<Void> updateCounter(Authenticator authenticator);

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/DummyStore.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/DummyStore.java
@@ -44,11 +44,20 @@ public class DummyStore implements CredentialStorage {
     long found = database.stream()
         .filter(entry -> authenticator.getCredID().equals(entry.getCredID()))
         .count();
-    if (found == 0) {
-      database.add(authenticator);
-      return Future.succeededFuture();
+    if (found != 0) {
+      return Future.failedFuture("Authenticator already exists");
     } else {
-      return Future.failedFuture("Duplicate authenticator");
+      // this is a new authenticator, make sure the user does not already exist, otherwise we risk adding 
+      // third-person credentials to an existing user
+      long existingUser = database.stream()
+          .filter(entry -> authenticator.getUserName().equals(entry.getUserName()))
+          .count();
+      if(existingUser == 0) {
+        database.add(authenticator);
+        return Future.succeededFuture();
+      } else {
+        return Future.failedFuture("User already exists");
+      }
     }
   }
 

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/NavigatorCredentialsCreateTest.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/NavigatorCredentialsCreateTest.java
@@ -1,7 +1,12 @@
 package io.vertx.tests;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.webauthn.*;
+import io.vertx.ext.auth.webauthn4j.Authenticator;
+import io.vertx.ext.auth.webauthn4j.RelyingParty;
+import io.vertx.ext.auth.webauthn4j.WebAuthn4J;
+import io.vertx.ext.auth.webauthn4j.WebAuthn4JCredentials;
+import io.vertx.ext.auth.webauthn4j.WebAuthn4JOptions;
+import io.vertx.ext.auth.webauthn4j.*;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
@@ -14,7 +19,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(VertxUnitRunner.class)
-public class NavigatorCredentialsCreate {
+public class NavigatorCredentialsCreateTest {
 
   private final DummyStore database = new DummyStore();
 
@@ -30,12 +35,11 @@ public class NavigatorCredentialsCreate {
   public void testRequestRegister(TestContext should) {
     final Async test = should.async();
 
-    WebAuthn webAuthN = WebAuthn.create(
+    WebAuthn4J webAuthN = WebAuthn4J.create(
         rule.vertx(),
-        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation"))
+        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation"))
           .setAttestation(Attestation.of("direct")))
-      .authenticatorFetcher(database::fetch)
-      .authenticatorUpdater(database::store);
+        .credentialStorage(database);
 
     // Dummy user
     JsonObject user = new JsonObject()
@@ -66,11 +70,10 @@ public class NavigatorCredentialsCreate {
   public void testRegister(TestContext should) {
     final Async test = should.async();
 
-    WebAuthn webAuthN = WebAuthn.create(
+    WebAuthn4J webAuthN = WebAuthn4J.create(
         rule.vertx(),
-        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
-      .authenticatorFetcher(database::fetch)
-      .authenticatorUpdater(database::store);
+        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
+        .credentialStorage(database);
 
     // dummy request
     JsonObject request = new JsonObject()
@@ -83,7 +86,7 @@ public class NavigatorCredentialsCreate {
 
     webAuthN
       .authenticate(
-        new WebAuthnCredentials()
+        new WebAuthn4JCredentials()
           .setUsername("paulo")
           .setOrigin("https://192.168.178.206.xip.io:8443")
           .setDomain("192.168.178.206.xip.io")
@@ -93,6 +96,47 @@ public class NavigatorCredentialsCreate {
       .onSuccess(response -> {
         assertNotNull(response);
         test.complete();
+      });
+  }
+
+  
+  @Test
+  public void testRegisterExistingUser(TestContext should) {
+    final Async test = should.async();
+
+    WebAuthn4J webAuthN = WebAuthn4J.create(
+        rule.vertx(),
+        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
+        .credentialStorage(database);
+
+    database.add(
+        new Authenticator()
+          .setUserName("paulo")
+          .setCredID("O3ZJlAdXvra6PwvL4I9AP99dS1_v3DDRuB_SwTAHFbUfMtvWTOFycCeb6CkXZXiPWi9Nr0ptUnlnHP3U40ptEA")
+          .setPublicKey("pQECAyYgASFYIBl0C67nFN_OwbODu_iE0hI5nM0ppUkqjhU9NhQvBaiLIlggffUTx8E6OM85huU3DcadeuaBBh8kGI8vdm3zesf3YRc")
+          .setCounter(2)
+      );
+
+    // dummy request
+    JsonObject request = new JsonObject()
+      .put("id", "Q-MHP0Xq20CKM5LW3qBt9gu5vdOYLNZc3jCcgyyLncRav5Ivd7T1dav3eWrI7CT8HmzU_yAYJrmja4in8OFL3A")
+      .put("rawId", "Q-MHP0Xq20CKM5LW3qBt9gu5vdOYLNZc3jCcgyyLncRav5Ivd7T1dav3eWrI7CT8HmzU_yAYJrmja4in8OFL3A")
+      .put("type", "public-key")
+      .put("response", new JsonObject()
+        .put("attestationObject", "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEfxV8VVBPmz66RLzscHpg5yjRhO28Y_fPwYO5AVwzBEJBAAAAAwAAAAAAAAAAAAAAAAAAAAAAQEPjBz9F6ttAijOS1t6gbfYLub3TmCzWXN4wnIMsi53EWr-SL3e09XWr93lqyOwk_B5s1P8gGCa5o2uIp_DhS9ylAQIDJiABIVggN_D3u-03a0GzONOHfaML881QZtOCc5oTNRB2wlyqUEUiWCD3878XoO_bIJf0mEPDILODFhVmkc4QeR6hOIDvwvXzYQ")
+        .put("clientDataJSON", "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiQkg3RUtJRFhVNkN0Xzk2eFR6RzBsNjJxTWhXX0VmX0s0TVFkRExvVk5jMVVYTVFZNHFOOWFnNXlETm1MSTd2RlJzbGtRYmJqMEpaV0p4R1ZmTXVnWGciLCJvcmlnaW4iOiJodHRwczovLzE5Mi4xNjguMTc4LjIwNi54aXAuaW86ODQ0MyIsImNyb3NzT3JpZ2luIjpmYWxzZX0"));
+
+    webAuthN
+      .authenticate(
+        new WebAuthn4JCredentials()
+          .setUsername("paulo")
+          .setOrigin("https://192.168.178.206.xip.io:8443")
+          .setDomain("192.168.178.206.xip.io")
+          .setChallenge("BH7EKIDXU6Ct_96xTzG0l62qMhW_Ef_K4MQdDLoVNc1UXMQY4qN9ag5yDNmLI7vFRslkQbbj0JZWJxGVfMugXg")
+          .setWebauthn(request))
+      .onFailure(x -> test.complete())
+      .onSuccess(response -> {
+        should.fail("We got logged in while another user already existed with the same user name");
       });
   }
 }

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/NavigatorCredentialsGetTest.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/NavigatorCredentialsGetTest.java
@@ -1,7 +1,7 @@
 package io.vertx.tests;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.webauthn.*;
+import io.vertx.ext.auth.webauthn4j.*;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(VertxUnitRunner.class)
-public class NavigatorCredentialsGet {
+public class NavigatorCredentialsGetTest {
 
   private final DummyStore database = new DummyStore();
 
@@ -30,11 +30,10 @@ public class NavigatorCredentialsGet {
   public void testRequestLogin(TestContext should) {
     final Async test = should.async();
 
-    WebAuthn webAuthN = WebAuthn.create(
+    WebAuthn4J webAuthN = WebAuthn4J.create(
         rule.vertx(),
-        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
-      .authenticatorFetcher(database::fetch)
-      .authenticatorUpdater(database::store);
+        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
+        .credentialStorage(database);
 
     database.add(
       new Authenticator()
@@ -61,11 +60,10 @@ public class NavigatorCredentialsGet {
   public void testLoginRequestChallenge(TestContext should) {
     final Async test = should.async();
 
-    WebAuthn webAuthN = WebAuthn.create(
+    WebAuthn4J webAuthN = WebAuthn4J.create(
         rule.vertx(),
-        new WebAuthnOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
-      .authenticatorFetcher(database::fetch)
-      .authenticatorUpdater(database::store);
+        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
+        .credentialStorage(database);
 
     database.add(
       new Authenticator()
@@ -87,7 +85,7 @@ public class NavigatorCredentialsGet {
         .put("signature", "MEUCIFXjL0ONRuLP1hkdlRJ8d0ofuRAS12c6w8WgByr-0yQZAiEAw-C6UZ8U8pi8irAcD6jXXaZMtezbzVwZXLGqY3sbFyA")
         .put("userHandle", ""));
 
-    webAuthN.authenticate(new WebAuthnCredentials()
+    webAuthN.authenticate(new WebAuthn4JCredentials()
         .setWebauthn(body)
         .setUsername("paulo")
         .setOrigin("https://192.168.178.206.xip.io:8443")


### PR DESCRIPTION
We want to make sure users implement credential storage properly, so we tell them what to do and what to watch out for.

This includes warning them about unicity of credential ID and user names, multiple credentials and what to do when trying to store multiple credentials for the same user name.