### PR TITLE
Rename Authenticator#userName to Authenticator#username

### DIFF
--- a/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/AttestationCertificatesConverter.java
+++ b/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/AttestationCertificatesConverter.java
@@ -2,6 +2,8 @@ package io.vertx.ext.auth.webauthn4j;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.ext.auth.webauthn4j.AttestationCertificates}.
@@ -14,7 +16,7 @@ public class AttestationCertificatesConverter {
       switch (member.getKey()) {
         case "alg":
           if (member.getValue() instanceof String) {
-            obj.setAlg(COSEAlgorithm.valueOf((String)member.getValue()));
+            obj.setAlg(io.vertx.ext.auth.webauthn4j.COSEAlgorithm.valueOf((String)member.getValue()));
           }
           break;
         case "x5c":

--- a/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/AuthenticatorConverter.java
+++ b/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/AuthenticatorConverter.java
@@ -14,9 +14,9 @@ public class AuthenticatorConverter {
    static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, Authenticator obj) {
     for (java.util.Map.Entry<String, Object> member : json) {
       switch (member.getKey()) {
-        case "userName":
+        case "username":
           if (member.getValue() instanceof String) {
-            obj.setUserName((String)member.getValue());
+            obj.setUsername((String)member.getValue());
           }
           break;
         case "type":
@@ -68,8 +68,8 @@ public class AuthenticatorConverter {
   }
 
    static void toJson(Authenticator obj, java.util.Map<String, Object> json) {
-    if (obj.getUserName() != null) {
-      json.put("userName", obj.getUserName());
+    if (obj.getUsername() != null) {
+      json.put("username", obj.getUsername());
     }
     if (obj.getType() != null) {
       json.put("type", obj.getType());

--- a/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/WebAuthn4JOptionsConverter.java
+++ b/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/WebAuthn4JOptionsConverter.java
@@ -2,6 +2,8 @@ package io.vertx.ext.auth.webauthn4j;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 /**
  * Converter and mapper for {@link io.vertx.ext.auth.webauthn4j.WebAuthn4JOptions}.
@@ -39,10 +41,10 @@ public class WebAuthn4JOptionsConverter {
           break;
         case "pubKeyCredParams":
           if (member.getValue() instanceof JsonArray) {
-            java.util.ArrayList<COSEAlgorithm> list =  new java.util.ArrayList<>();
+            java.util.ArrayList<io.vertx.ext.auth.webauthn4j.COSEAlgorithm> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof String)
-                list.add(COSEAlgorithm.valueOf((String)item));
+                list.add(io.vertx.ext.auth.webauthn4j.COSEAlgorithm.valueOf((String)item));
             });
             obj.setPubKeyCredParams(list);
           }

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/Authenticator.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/Authenticator.java
@@ -37,7 +37,7 @@ public class Authenticator {
   /**
    * The username linked to this authenticator
    */
-  private String userName;
+  private String username;
 
   /**
    * The type of key (must be "public-key")
@@ -87,12 +87,12 @@ public class Authenticator {
     AuthenticatorConverter.fromJson(json, this);
   }
 
-  public String getUserName() {
-    return userName;
+  public String getUsername() {
+    return username;
   }
 
-  public Authenticator setUserName(String userName) {
-    this.userName = userName;
+  public Authenticator setUsername(String username) {
+    this.username = username;
     return this;
   }
 

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/impl/WebAuthn4JImpl.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/impl/WebAuthn4JImpl.java
@@ -47,7 +47,6 @@ import com.webauthn4j.async.metadata.anchor.MetadataBLOBBasedTrustAnchorAsyncRep
 import com.webauthn4j.async.verifier.attestation.statement.androidkey.AndroidKeyAttestationStatementAsyncVerifier;
 import com.webauthn4j.async.verifier.attestation.statement.androidsafetynet.AndroidSafetyNetAttestationStatementAsyncVerifier;
 import com.webauthn4j.async.verifier.attestation.statement.apple.AppleAnonymousAttestationStatementAsyncVerifier;
-import com.webauthn4j.async.verifier.attestation.statement.none.NoneAttestationStatementAsyncVerifier;
 import com.webauthn4j.async.verifier.attestation.statement.packed.PackedAttestationStatementAsyncVerifier;
 import com.webauthn4j.async.verifier.attestation.statement.tpm.TPMAttestationStatementAsyncVerifier;
 import com.webauthn4j.async.verifier.attestation.statement.u2f.FIDOU2FAttestationStatementAsyncVerifier;
@@ -438,7 +437,7 @@ public class WebAuthn4JImpl implements WebAuthn4J {
         		  .compose(authrInfo -> {
         			  // by default the store can upsert if a credential is missing, the user has been verified so it is valid
         			  // the store however might disallow this operation
-        			  authrInfo.setUserName(username);
+        			  authrInfo.setUsername(username);
 
         			  // the create challenge is complete we can finally save this
         			  // new authenticator to the storage

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/DummyStore.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/DummyStore.java
@@ -27,7 +27,7 @@ public class DummyStore implements CredentialStorage {
       database.stream()
         .filter(entry -> {
           if (userName != null) {
-            return userName.equals(entry.getUserName());
+            return userName.equals(entry.getUsername());
           }
           if (credentialId != null) {
             return credentialId.equals(entry.getCredID());
@@ -47,10 +47,10 @@ public class DummyStore implements CredentialStorage {
     if (found != 0) {
       return Future.failedFuture("Authenticator already exists");
     } else {
-      // this is a new authenticator, make sure the user does not already exist, otherwise we risk adding 
+      // this is a new authenticator, make sure the user does not already exist, otherwise we risk adding
       // third-person credentials to an existing user
       long existingUser = database.stream()
-          .filter(entry -> authenticator.getUserName().equals(entry.getUserName()))
+          .filter(entry -> authenticator.getUsername().equals(entry.getUsername()))
           .count();
       if(existingUser == 0) {
         database.add(authenticator);

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/EmulatorTest.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/EmulatorTest.java
@@ -29,7 +29,6 @@ import com.webauthn4j.converter.AuthenticationExtensionsClientOutputsConverter;
 import com.webauthn4j.converter.AuthenticatorDataConverter;
 import com.webauthn4j.converter.exception.DataConversionException;
 import com.webauthn4j.converter.util.ObjectConverter;
-import com.webauthn4j.data.attestation.authenticator.AAGUID;
 import com.webauthn4j.data.attestation.authenticator.AttestedCredentialData;
 import com.webauthn4j.data.attestation.statement.COSEAlgorithmIdentifier;
 import com.webauthn4j.data.client.Origin;
@@ -271,7 +270,7 @@ public class EmulatorTest {
 		.flatMap(user -> {
 			assertNotNull(user);
 			// make sure we have the right user name
-			assertEquals(username, user.principal().getString("userName"));
+			assertEquals(username, user.subject());
 			// also make sure we saved the user in the DB under that username
 			return database.find(username, null);
 		})
@@ -280,7 +279,7 @@ public class EmulatorTest {
 			assertEquals(1, authenticators.size());
 			Authenticator authenticator = authenticators.get(0);
 			// Check username, credid, counter, publicKey
-			assertEquals(username, authenticator.getUserName());
+			assertEquals(username, authenticator.getUsername());
 			assertEquals(should.get("credId"), authenticator.getCredID());
 			should.put("counter", authenticator.getCounter());
 			assertEquals(should.get("publicKey"), authenticator.getPublicKey());
@@ -357,7 +356,7 @@ public class EmulatorTest {
 		.flatMap(user -> {
 			assertNotNull(user);
 			// make sure we have the right user name
-			assertEquals(username, user.principal().getString("userName"));
+			assertEquals(username, user.subject());
 			// also make sure we saved the user in the DB under that username
 			return database.find(username, null);
 		})
@@ -366,7 +365,7 @@ public class EmulatorTest {
 			assertEquals(1, authenticators.size());
 			Authenticator authenticator = authenticators.get(0);
 			// Check username, credid, counter, publicKey
-			assertEquals(username, authenticator.getUserName());
+			assertEquals(username, authenticator.getUsername());
 			assertEquals(should.get("credId"), authenticator.getCredID());
 			assertEquals(should.<Long>get("counter") + 1, authenticator.getCounter());
 			assertEquals(should.get("publicKey"), authenticator.getPublicKey());

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/NavigatorCredentialsCreateTest.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/NavigatorCredentialsCreateTest.java
@@ -99,7 +99,7 @@ public class NavigatorCredentialsCreateTest {
       });
   }
 
-  
+
   @Test
   public void testRegisterExistingUser(TestContext should) {
     final Async test = should.async();
@@ -111,7 +111,7 @@ public class NavigatorCredentialsCreateTest {
 
     database.add(
         new Authenticator()
-          .setUserName("paulo")
+          .setUsername("paulo")
           .setCredID("O3ZJlAdXvra6PwvL4I9AP99dS1_v3DDRuB_SwTAHFbUfMtvWTOFycCeb6CkXZXiPWi9Nr0ptUnlnHP3U40ptEA")
           .setPublicKey("pQECAyYgASFYIBl0C67nFN_OwbODu_iE0hI5nM0ppUkqjhU9NhQvBaiLIlggffUTx8E6OM85huU3DcadeuaBBh8kGI8vdm3zesf3YRc")
           .setCounter(2)

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/NavigatorCredentialsGetTest.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/NavigatorCredentialsGetTest.java
@@ -37,7 +37,7 @@ public class NavigatorCredentialsGetTest {
 
     database.add(
       new Authenticator()
-        .setUserName("paulo")
+        .setUsername("paulo")
         .setCredID("O3ZJlAdXvra6PwvL4I9AP99dS1_v3DDRuB_SwTAHFbUfMtvWTOFycCeb6CkXZXiPWi9Nr0ptUnlnHP3U40ptEA")
         .setPublicKey("pQECAyYgASFYIBl0C67nFN_OwbODu_iE0hI5nM0ppUkqjhU9NhQvBaiLIlggffUTx8E6OM85huU3DcadeuaBBh8kGI8vdm3zesf3YRc")
         .setCounter(2)
@@ -67,7 +67,7 @@ public class NavigatorCredentialsGetTest {
 
     database.add(
       new Authenticator()
-        .setUserName("paulo")
+        .setUsername("paulo")
         .setCredID("rYLaf9xagyA2YnO-W3CZDW8udSg8VeMMm25nenU7nCSxUqy1pEzOdb9oFrDxZZDmrp3odfuTPuONQCiSMH-Tyg")
         .setPublicKey("pQECAyYgASFYILBNcdWmiMsmjA1QkNpG91GpEbhMIOqWLieDP6mLnGETIlggGMiqXz8BuSiPa0ovGVxxxbdUbJVm6THKNhUCifFhJCE")
         .setCounter(4)


### PR DESCRIPTION
Motivation:

The `Authenticator#userName` field name is used by the construction of the User instance based on the data object to JSON converter. The `User#subject()` method maps the `username` value of the principal built from the JSON representation, leading to return `null` instead of the user name.

Change:

Rename `Authenticator#userName` as well as the property accessors to username and update the tests accordingly.
