### PR TITLE
io.vertx.ext.auth.authentication.Credentials should be a data object interface

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authentication/Credentials.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authentication/Credentials.java
@@ -15,7 +15,7 @@
  */
 package io.vertx.ext.auth.authentication;
 
-import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 
@@ -25,7 +25,7 @@ import io.vertx.core.json.JsonObject;
  *
  * @author Paulo Lopes
  */
-@VertxGen(concrete = false)
+@DataObject
 public interface Credentials {
   /**
    * Implementors should override this method to perform validation. An argument is allowed to


### PR DESCRIPTION
Motivation:

`io.vertx.ext.auth.authentication.Credentials` is a code generated object, however its implementations are data objects. Generated code declaring `Credentials` as argument or return type does not accept `Credentials` implementation since the type is translated to the shim equivalent.

Changes:

Make `Credentials` a data object.
