### PR TITLE
Fix bug to read sub string correctly

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/VariableAwareExpression.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/VariableAwareExpression.java
@@ -34,7 +34,7 @@ public class VariableAwareExpression {
       int openingCurlyBracePos = value.indexOf("{", currentPos);
       if (openingCurlyBracePos == -1) {
         if (currentPos < value.length()) {
-          String authorizationPart = value.substring(currentPos, value.length() - currentPos);
+          String authorizationPart = value.substring(currentPos);
           tmpParts.add(ctx -> authorizationPart);
         }
         break;

--- a/vertx-auth-common/src/test/java/io/vertx/tests/authorization/impl/VariableAwareExpressionTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/tests/authorization/impl/VariableAwareExpressionTest.java
@@ -21,4 +21,32 @@ public class VariableAwareExpressionTest {
     String resolved = expression.resolve(MultiMap.caseInsensitiveMultiMap().add("foo", "bar"));
     assertEquals("bar", resolved);
   }
+
+  @Test
+  public void test2() {
+    VariableAwareExpression expression = new VariableAwareExpression("{bar}end");
+    String resolved = expression.resolve(MultiMap.caseInsensitiveMultiMap().add("bar", "foo"));
+    assertEquals("fooend", resolved);
+  }
+
+  @Test
+  public void test3() {
+    VariableAwareExpression expression = new VariableAwareExpression("begin{bar}");
+    String resolved = expression.resolve(MultiMap.caseInsensitiveMultiMap().add("bar", "foo"));
+    assertEquals("beginfoo", resolved);
+  }
+
+  @Test
+  public void test4() {
+    VariableAwareExpression expression = new VariableAwareExpression("part1,part2{bar}");
+    String resolved = expression.resolve(MultiMap.caseInsensitiveMultiMap().add("bar", "foo"));
+    assertEquals("part1,part2foo", resolved);
+  }
+
+  @Test
+  public void test5() {
+    VariableAwareExpression expression = new VariableAwareExpression("part1{bar}part2,part3");
+    String resolved = expression.resolve(MultiMap.caseInsensitiveMultiMap().add("bar", "foo"));
+    assertEquals("part1foopart2,part3", resolved);
+  }
 }


### PR DESCRIPTION
Motivation:

`substring` to get remaining part of `String` in `VariableAwareExpression` has a bug. It is using the length of the string in second index, instead of using last position + 1 of required substring. Without this fix, expressions like {foo}bar can not be processed. This patch fixes it. 

