### PR TITLE
Fix bug in VariableAwareExpression that does not correctly parses expression

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/VariableAwareExpression.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/authorization/impl/VariableAwareExpression.java
@@ -35,7 +35,7 @@ class VariableAwareExpression {
       int openingCurlyBracePos = value.indexOf("{", currentPos);
       if (openingCurlyBracePos == -1) {
         if (currentPos < value.length()) {
-          String authorizationPart = value.substring(currentPos, value.length() - currentPos);
+          String authorizationPart = value.substring(currentPos);
           tmpParts.add(ctx -> authorizationPart);
         }
         break;

--- a/vertx-auth-common/src/test/java/io/vertx/ext/auth/authorization/impl/VariableAwareExpressionTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/ext/auth/authorization/impl/VariableAwareExpressionTest.java
@@ -1,0 +1,61 @@
+package io.vertx.ext.auth.authorization.impl;
+
+import io.vertx.core.MultiMap;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authorization.AuthorizationContext;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.junit.Assert.assertEquals;
+
+public class VariableAwareExpressionTest {
+
+  @Test
+  public void test2() {
+    VariableAwareExpression expression = new VariableAwareExpression("{bar}end");
+    String resolved = expression.resolve(new MockAuthorizationContext(MultiMap.caseInsensitiveMultiMap().add("bar", "foo")));
+    Function<AuthorizationContext, String>[] parts = expression.parts();
+    assertEquals("fooend", resolved);
+  }
+
+  @Test
+  public void test3() {
+    VariableAwareExpression expression = new VariableAwareExpression("begin{bar}");
+    String resolved = expression.resolve(new MockAuthorizationContext(MultiMap.caseInsensitiveMultiMap().add("bar", "foo")));
+    assertEquals("beginfoo", resolved);
+  }
+
+  @Test
+  public void test4() {
+    VariableAwareExpression expression = new VariableAwareExpression("part1,part2{bar}");
+    String resolved = expression.resolve(new MockAuthorizationContext(MultiMap.caseInsensitiveMultiMap().add("bar", "foo")));
+    assertEquals("part1,part2foo", resolved);
+  }
+
+  @Test
+  public void test5() {
+    VariableAwareExpression expression = new VariableAwareExpression("part1{bar}part2,part3");
+    String resolved = expression.resolve(new MockAuthorizationContext(MultiMap.caseInsensitiveMultiMap().add("bar", "foo")));
+    assertEquals("part1foopart2,part3", resolved);
+  }
+
+  private static class MockAuthorizationContext implements AuthorizationContext {
+
+    private final MultiMap variables;
+
+    public MockAuthorizationContext(MultiMap variables) {
+      this.variables = variables;
+    }
+
+    @Override
+    public User user() {
+      return null;
+    }
+
+    @Override
+    public MultiMap variables() {
+      return variables;
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

`VariableAwareExpression` uses substring to get remaining part of String. It has a bug, it is using the length of the string in second index, instead of using last position + 1 of required substring. Without this fix, expressions like _{foo}bar_ can not be processed.

Changes:

This patch fixes it.
