### PR TITLE
Scope from jwt should be correctly propagated to the user principal

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -546,6 +546,11 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
           user.attributes()
             .put("rootClaim", "accessToken");
 
+          // scope can be present inside JWT and this should be copied to user principal as it is expected from AuthHandler
+          if (token.containsKey("scope")) {
+            user.principal().put("scope", token.getString("scope"));
+          }
+
         } catch (DecodeException | IllegalArgumentException e) {
           // This set of exceptions here are a valid cases
           // the reason is that it can be for several factors,

--- a/vertx-auth-oauth2/src/test/java/io/vertx/tests/Oauth2TokenScopeTest.java
+++ b/vertx-auth-oauth2/src/test/java/io/vertx/tests/Oauth2TokenScopeTest.java
@@ -127,7 +127,13 @@ public class Oauth2TokenScopeTest {
         } else {
           User token = res.result();
           should.assertFalse(token.expired());
-          test.complete();
+          ScopeAuthorization.create(" ").getAuthorizations(token)
+            .onComplete(call -> {
+              should.assertTrue(call.succeeded());
+              should.assertTrue(PermissionBasedAuthorization.create("scopeA").match(token));
+              should.assertTrue(PermissionBasedAuthorization.create("scopeB").match(token));
+              test.complete();
+            });
         }
       });
   }
@@ -198,7 +204,6 @@ public class Oauth2TokenScopeTest {
             should.assertTrue(call.succeeded());
             // the scopes are missing
             should.assertFalse(PermissionBasedAuthorization.create("scopeX").match(res.result()));
-            should.assertFalse(PermissionBasedAuthorization.create("scopeB").match(res.result()));
             test.complete();
           });
       });


### PR DESCRIPTION
Motivation:

Scopes that are present inside a JWT MUST be propagated to the user, specifically to the principal. 

I caught this bug while working on OpenAPI specification where I used RouterBuilder with automatic security handler that was also generated from spec. If request landed with a bearer token (bearer only handler) OAuth2AuthHandler failed to validate the scopes despite having set scopes on the OAuth2AuthHandler. Handler allowed request with JWT that had invalid scopes. This is because handler only checks if user has scopes, if scopes are not present validation is not done.

 https://github.com/vert-x3/vertx-web/blob/a7917a02e0d6ff6b498b17a9ad74094f564b4ae7/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/OAuth2AuthHandlerImpl.java#L347-L380

I also noticed that after my changes some tests failed. After taking a closer look and double checking the tests I positives there was a bug in tests also hence I updated them also.

I would like also to backport this to vertx 4 as it is a critical bug.

