### PR TITLE
Update MetaDataServiceTest.java

### DIFF
--- a/vertx-auth-webauthn/src/test/java/io/vertx/ext/auth/webauthn/MetaDataServiceTest.java
+++ b/vertx-auth-webauthn/src/test/java/io/vertx/ext/auth/webauthn/MetaDataServiceTest.java
@@ -6,6 +6,7 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,6 +20,7 @@ public class MetaDataServiceTest {
   public RunTestOnContext rule = new RunTestOnContext();
 
   @Test
+  @Ignore("MDS2 is deprecated and not available anymore, all certificates have expired")
   public void testVerify() {
 
     // defaults


### PR DESCRIPTION
Disable old MDS2 test as it is long deprecated and certificates expired