### PR TITLE
Improve error messages

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -367,7 +367,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
             // final step, verify if the user is not expired
             // this may happen if the user tokens have been issued for future use for example
             if (newUser.expired(config.getJWTOptions().getLeeway())) {
-              return Future.failedFuture("user is expired.");
+              return Future.failedFuture("introspected user is expired.");
             } else {
               // basic validation passed, the token is not expired
               return Future.succeededFuture(newUser);
@@ -458,7 +458,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
           // final step, verify if the user is not expired
           // this may happen if the user tokens have been issued for future use for example
           if (newUser.expired(config.getJWTOptions().getLeeway())) {
-            return Future.failedFuture("user is expired.");
+            return Future.failedFuture("user is expired on code-to-token.");
           } else {
             // basic validation passed, the token is not expired
             return Future.succeededFuture(newUser);
@@ -496,7 +496,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
         // final step, verify if the user is not expired
         // this may happen if the user tokens have been issued for future use for example
         if (newUser.expired(config.getJWTOptions().getLeeway())) {
-          return Future.failedFuture("user is expired.");
+          return Future.failedFuture("refreshed user is expired.");
         } else {
           // basic validation passed, the token is not expired
           return Future.succeededFuture(newUser);
@@ -532,7 +532,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
         // final step, verify if the user is not expired
         // this may happen if the user tokens have been issued for future use for example
         if (user.expired(config.getJWTOptions().getLeeway())) {
-          return Future.failedFuture("user is expired.");
+          return Future.failedFuture("user is expired on user info.");
         } else {
           // basic validation passed, the user token is not expired
           return Future.succeededFuture(json);

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -367,7 +367,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
             // final step, verify if the user is not expired
             // this may happen if the user tokens have been issued for future use for example
             if (newUser.expired(config.getJWTOptions().getLeeway())) {
-              return Future.failedFuture("Used is expired.");
+              return Future.failedFuture("user is expired.");
             } else {
               // basic validation passed, the token is not expired
               return Future.succeededFuture(newUser);
@@ -458,7 +458,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
           // final step, verify if the user is not expired
           // this may happen if the user tokens have been issued for future use for example
           if (newUser.expired(config.getJWTOptions().getLeeway())) {
-            return Future.failedFuture("Used is expired.");
+            return Future.failedFuture("user is expired.");
           } else {
             // basic validation passed, the token is not expired
             return Future.succeededFuture(newUser);
@@ -496,7 +496,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
         // final step, verify if the user is not expired
         // this may happen if the user tokens have been issued for future use for example
         if (newUser.expired(config.getJWTOptions().getLeeway())) {
-          return Future.failedFuture("Used is expired.");
+          return Future.failedFuture("user is expired.");
         } else {
           // basic validation passed, the token is not expired
           return Future.succeededFuture(newUser);
@@ -532,7 +532,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
         // final step, verify if the user is not expired
         // this may happen if the user tokens have been issued for future use for example
         if (user.expired(config.getJWTOptions().getLeeway())) {
-          return Future.failedFuture("Used is expired.");
+          return Future.failedFuture("user is expired.");
         } else {
           // basic validation passed, the user token is not expired
           return Future.succeededFuture(json);


### PR DESCRIPTION
Motivation:

This PR includes two commits:

* In the first commit, some typos are fixed.
* In the second commit, some error messages are improved in its wording. As all of them have at the moment the same message, it is hard to know where exactly the error came from at first glance. The improved error messages try to be a bit more helpful. Let me know what you think!

The second commit is a suggestion and could be dropped, if it does not convince.