### PR TITLE
Fix synchronization for JWT increasing performance for token validation

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWE.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWE.java
@@ -19,10 +19,7 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
+import java.security.*;
 
 /**
  * Utilities to work with Json Web Encryption. This is not fully implemented according to the RFC/spec.
@@ -31,7 +28,6 @@ import java.security.PublicKey;
  */
 public final class JWE {
 
-  private final Cipher cipher;
   private final JWK jwk;
 
   public JWE(JWK jwk) {
@@ -40,7 +36,7 @@ public final class JWE {
     }
 
     try {
-      this.cipher = Cipher.getInstance(jwk.kty());
+      Cipher.getInstance(jwk.kty()); //just validate if cipher is available
     } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
       throw new RuntimeException(e);
     }
@@ -53,10 +49,13 @@ public final class JWE {
       throw new IllegalStateException("Key doesn't contain a pubKey material");
     }
 
-    synchronized (cipher) {
+    try {
+      Cipher cipher = Cipher.getInstance(jwk.kty());
       cipher.init(Cipher.ENCRYPT_MODE, publicKey);
       cipher.update(payload);
       return cipher.doFinal();
+    } catch (NoSuchPaddingException | NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
     }
   }
 
@@ -66,10 +65,13 @@ public final class JWE {
       throw new IllegalStateException("Key doesn't contain a secKey material");
     }
 
-    synchronized (cipher) {
+    try {
+      Cipher cipher = Cipher.getInstance(jwk.kty());
       cipher.init(Cipher.DECRYPT_MODE, privateKey);
       cipher.update(payload);
       return cipher.doFinal();
+    } catch (NoSuchPaddingException | NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/jose/JWK.java
@@ -663,7 +663,14 @@ public final class JWK {
   }
 
   public Mac mac() {
-    return mac;
+    if (mac == null) {
+      return null;
+    }
+    try {
+      return (Mac) mac.clone();
+    } catch (CloneNotSupportedException e) {
+      return mac;
+    }
   }
 
   public PublicKey publicKey() {

--- a/vertx-auth-common/src/main/java/module-info.java
+++ b/vertx-auth-common/src/main/java/module-info.java
@@ -19,6 +19,7 @@ module io.vertx.auth.common {
   requires static io.vertx.codegen.api;
   requires static io.vertx.codegen.json;
   requires static io.vertx.docgen;
+  requires io.netty.common;
 
   exports io.vertx.ext.auth;
   exports io.vertx.ext.auth.authorization;


### PR DESCRIPTION
Motivation:

The observation was that reusing objects like Signature, Cipher and Mac and running it within synchronization blocks has a big impact on application performance. Used in a handler it serializes all eventloop threads and potentially introduces a lot of wait for all other threads. 

Using the `Signature.getInstance​(String algorithm)` does not add a lot of overhead and is then safe to use within the same context for the operation.

Doing some performance tests on EC256 signatures got me nearly the same performance multiplicator as CPU cores available.