### PR TITLE
OpenID Connect: Respect the configured flow types if the server sends none

### DIFF
--- a/vertx-auth-oauth2/pom.xml
+++ b/vertx-auth-oauth2/pom.xml
@@ -32,6 +32,18 @@
     <vertx.surefire.useModulePath>false</vertx.surefire.useModulePath>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>1.21.3</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -50,8 +62,17 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.18.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mockserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-client-java</artifactId>
+      <version>5.15.0</version>
     </dependency>
   </dependencies>
 

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/OpenIDConnectAuth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/OpenIDConnectAuth.java
@@ -19,12 +19,17 @@ import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.impl.http.SimpleHttpClient;
 import io.vertx.ext.auth.oauth2.OAuth2Auth;
 import io.vertx.ext.auth.oauth2.OAuth2Options;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Simplified factory to create an {@link io.vertx.ext.auth.oauth2.OAuth2Auth} for OpenID Connect.
@@ -134,15 +139,39 @@ public interface OpenIDConnectAuth {
           jwtOptions.setIssuer(json.getString("issuer"));
         }
 
-
-
         if (json.containsKey("grant_types_supported")) {
+          // optional config
+          List<String> configuredGrantTypes = config.getSupportedGrantTypes();
+          final Set<String> configured = configuredGrantTypes == null ? null : new HashSet<>(configuredGrantTypes);
+
           // reset config
           config.setSupportedGrantTypes(null);
 
-          // optional config
-          JsonArray flows = json.getJsonArray("grant_types_supported");
-          flows.forEach(el -> config.addSupportedGrantType((String) el));
+          Stream<String> supportedGrantTypes = json.getJsonArray("grant_types_supported")
+            .stream()
+            .map(el -> (String) el);
+
+          // If the caller configured supported grant types, use the intersection with the server-supported grant types.
+          // Otherwise, use all grant types that the server supports.
+          if (configured != null) {
+            supportedGrantTypes = supportedGrantTypes.filter(configured::contains);
+          }
+
+          supportedGrantTypes
+            .forEach(config::addSupportedGrantType);
+
+          // If the supported grant types are still null here, either the server sent an empty list of supported grant
+          // types or the intersection with the configured grant types was empty. Both cases are errors.
+          if (config.getSupportedGrantTypes() == null) {
+            return Future.failedFuture(
+              "No supported grant types with this authorization provider. Supported: " +
+                json.getJsonArray("grant_types_supported").stream()
+                  .map(el -> (String) el)
+                  .collect(Collectors.joining(", ", "[", "]")) +
+                ". Configured: " +
+                (configuredGrantTypes == null ? "<any>" : configuredGrantTypes.stream().collect(Collectors.joining(", ", "[", "]")))
+            );
+          }
         }
 
         try {

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/OpenIDConnectAuth.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/providers/OpenIDConnectAuth.java
@@ -135,10 +135,11 @@ public interface OpenIDConnectAuth {
         }
 
 
-        // reset config
-        config.setSupportedGrantTypes(null);
 
         if (json.containsKey("grant_types_supported")) {
+          // reset config
+          config.setSupportedGrantTypes(null);
+
           // optional config
           JsonArray flows = json.getJsonArray("grant_types_supported");
           flows.forEach(el -> config.addSupportedGrantType((String) el));


### PR DESCRIPTION
Motivation:

The `OpenIDConnectAuth` unconditionally resets the `supportedGrantTypes` of `OAuth2Options` to `null`. Therefore, the previously configured grant types are ignored and replaced by the default (`implicit, auth_code`). This triggers a configuration validation exception if no `clientId` is configured. In use cases that only need OAuth token validation functionality, this behavior is undesired, as they might never need a client ID.

This is fixed by only resetting `supportedGrantTypes` when the authentication server sends `grant_types_supported` on its own.

Fixes #729 

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
