### PR TITLE
Remove stacktrace from warn message in case Unsupported JWK

### DIFF
--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -77,7 +77,9 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
         try {
           jwt.addJWK(new JWK(pubSecKey));
         } catch (RuntimeException e) {
-          LOG.warn(String.format("Unsupported JWK %s", e.getMessage()));
+          if (LOG.isDebugEnabled()) {
+            LOG.warn("Unsupported JWK", e);
+          }
         }
       }
     }
@@ -87,7 +89,9 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
         try {
           jwt.addJWK(new JWK(jwk));
         } catch (RuntimeException e) {
-          LOG.warn(String.format("Unsupported JWK %s", e.getMessage()));
+          if (LOG.isDebugEnabled()) {
+            LOG.warn("Unsupported JWK", e);
+          }
         }
       }
     }
@@ -136,7 +140,9 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
             try {
               jwt.addJWK(new JWK((JsonObject) key));
             } catch (Exception e) {
-              LOG.warn(String.format("Unsupported JWK %s", e.getMessage()));
+              if (LOG.isDebugEnabled()) {
+                LOG.warn("Unsupported JWK", e);
+              }
             }
           }
           // swap

--- a/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
+++ b/vertx-auth-oauth2/src/main/java/io/vertx/ext/auth/oauth2/impl/OAuth2AuthProviderImpl.java
@@ -77,7 +77,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
         try {
           jwt.addJWK(new JWK(pubSecKey));
         } catch (RuntimeException e) {
-          LOG.warn("Unsupported JWK", e);
+          LOG.warn(String.format("Unsupported JWK %s", e.getMessage()));
         }
       }
     }
@@ -87,7 +87,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
         try {
           jwt.addJWK(new JWK(jwk));
         } catch (RuntimeException e) {
-          LOG.warn("Unsupported JWK", e);
+          LOG.warn(String.format("Unsupported JWK %s", e.getMessage()));
         }
       }
     }
@@ -136,7 +136,7 @@ public class OAuth2AuthProviderImpl implements OAuth2Auth, Closeable {
             try {
               jwt.addJWK(new JWK((JsonObject) key));
             } catch (Exception e) {
-              LOG.warn("Unsupported JWK", e);
+              LOG.warn(String.format("Unsupported JWK %s", e.getMessage()));
             }
           }
           // swap


### PR DESCRIPTION
If unsupported algorithm is detected a warn message with full stacktrace is shown.
There is no useful information from the stacktrace.
Having full stacktrace to in warn log in my opinion is not ideal.

I have updated the log message to only show unsupported algorithm. 

