### PR TITLE
Do not wrap array attributes in a new array on User.merge

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/UserImpl.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/impl/UserImpl.java
@@ -139,7 +139,7 @@ public class UserImpl implements User, ClusterSerializable {
           Object rhsValue = otherAttrs.getValue(key);
           // accumulate
           if (lhsValue == null) {
-            attrs.put(key, rhsValue instanceof JsonArray ? new JsonArray().add(rhsValue) : rhsValue);
+            attrs.put(key, rhsValue instanceof JsonArray ? ((JsonArray) rhsValue).copy() : rhsValue);
           } else if (lhsValue instanceof JsonArray) {
             if (rhsValue instanceof JsonArray) {
               ((JsonArray) lhsValue).addAll((JsonArray) rhsValue);

--- a/vertx-auth-common/src/test/java/io/vertx/tests/UserTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/tests/UserTest.java
@@ -177,6 +177,31 @@ public class UserTest {
   }
 
   @Test
+  public void testMergeArrayAttributeMissingOnOneSide() {
+    User userA, userB;
+
+    // 1st user has no attributes, the 2nd user array attribute should be kept as is
+
+    userA = User.create(new JsonObject().put("access_token", "A"));
+    userB = User.create(new JsonObject().put("access_token", "B"), new JsonObject().put("roles", new JsonArray().add("write")));
+
+    userA.merge(userB);
+
+    // expectation
+    assertEquals(new JsonArray().add("write"), userA.attributes().getJsonArray("roles"));
+
+    // 2nd user has no attributes, the 1st user array attribute should be kept as is
+
+    userA = User.create(new JsonObject().put("access_token", "A"), new JsonObject().put("roles", new JsonArray().add("read")));
+    userB = User.create(new JsonObject().put("access_token", "B"));
+
+    userA.merge(userB);
+
+    // expectation
+    assertEquals(new JsonArray().add("read"), userA.attributes().getJsonArray("roles"));
+  }
+
+  @Test
   public void testMergeAmr() {
     User userA, userB;
 


### PR DESCRIPTION
When merging two `User` objects where only the merged-in user has an array attribute for a given key, `User.merge` wrapped that array in a new array: `roles = ["write"]` became `roles = [["write"]]`.

The accumulate logic in `UserImpl.merge` handled every combination correctly (array+array concatenates, scalar+scalar becomes a two-element array, ...) except the case where the current user has no value for the key and the other user's value is an array — that branch added the whole array as a single element. This change keeps a copy of the other user's array instead, consistent with the copy the method already makes when the whole attributes object is absent.

Added coverage to `UserTest` for array attributes present on only one side of the merge (both directions).

Fixes #550