### PR TITLE
Document the JSON form of PubSecKeyOptions buffer

### DIFF
--- a/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
+++ b/vertx-auth-common/src/main/java/io/vertx/ext/auth/PubSecKeyOptions.java
@@ -8,6 +8,17 @@ import io.vertx.core.json.JsonObject;
 
 /**
  * Options describing Key stored in PEM format.
+ * <p>
+ * When these options are created from JSON (for example when loading the configuration from a file), the
+ * {@code buffer} field is a {@link Buffer}, which in JSON is represented as the <b>base64</b> encoding of the key
+ * bytes, <b>not</b> the PEM text itself. Given the PEM (or secret) as a String, the JSON form can be obtained with
+ * {@code new PubSecKeyOptions().setBuffer(pem).toJson()}, e.g.:
+ * <pre>
+ * {
+ *   "algorithm": "ES256",
+ *   "buffer": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0K..."
+ * }
+ * </pre>
  *
  * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
  */
@@ -75,6 +86,9 @@ public class PubSecKeyOptions {
    * The PEM or Secret key buffer. When working with secret materials, the material is expected to be encoded in
    * {@code UTF-8}. PEM files are expected to be {@code US_ASCII} as the format uses a base64 encoding for the
    * payload.
+   * <p>
+   * This setter is a convenience for Java code and takes the PEM/secret text as is. In JSON the {@code buffer}
+   * field must be the base64 encoding of these bytes, see {@link #setBuffer(Buffer)}.
    *
    * @return self.
    */
@@ -88,6 +102,9 @@ public class PubSecKeyOptions {
    * The PEM or Secret key buffer. When working with secret materials, the material is expected to be encoded in
    * {@code UTF-8}. PEM files are expected to be {@code US_ASCII} as the format uses a base64 encoding for the
    * payload.
+   * <p>
+   * This is the setter used when the options are created from JSON: the JSON value of {@code buffer} is the
+   * base64 encoding of the key bytes (the standard JSON representation of a {@link Buffer}).
    *
    * @return self.
    */

--- a/vertx-auth-common/src/test/java/io/vertx/tests/PubSecKeyOptionsTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/tests/PubSecKeyOptionsTest.java
@@ -1,0 +1,70 @@
+package io.vertx.tests;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.PubSecKeyOptions;
+import io.vertx.ext.auth.impl.jose.JWK;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.Assert.*;
+
+/**
+ * Documents the JSON representation of {@link PubSecKeyOptions}: the {@code buffer} field is the base64 encoding
+ * of the key bytes (a {@link Buffer} in JSON), not the PEM text itself.
+ *
+ * @see <a href="https://github.com/eclipse-vertx/vertx-auth/issues/596">#596</a>
+ */
+public class PubSecKeyOptionsTest {
+
+  private static final String PEM =
+    "-----BEGIN PUBLIC KEY-----\n" +
+      "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEraVJ8CpkrwTPRCPluUDdwC6b8+m4\n" +
+      "dEjwl8s+Sn0GULko+H95fsTREQ1A2soCFHS4wV3/23Nebq9omY3KuK9DKw==\n" +
+      "-----END PUBLIC KEY-----";
+
+  @Test
+  public void testJsonRoundTrip() {
+    PubSecKeyOptions original = new PubSecKeyOptions()
+      .setAlgorithm("ES256")
+      .setId("k1")
+      .setBuffer(PEM);
+
+    JsonObject json = original.toJson();
+    // in JSON the buffer is base64 encoded, not the PEM text
+    assertEquals(Base64.getEncoder().encodeToString(PEM.getBytes(StandardCharsets.UTF_8)), json.getString("buffer"));
+
+    PubSecKeyOptions copy = new PubSecKeyOptions(json);
+    assertEquals("ES256", copy.getAlgorithm());
+    assertEquals("k1", copy.getId());
+    assertEquals(PEM, copy.getBuffer().toString(StandardCharsets.UTF_8));
+    assertEquals(original.toJson(), copy.toJson());
+  }
+
+  @Test
+  public void testFromJsonWithBase64Pem() {
+    JsonObject json = new JsonObject()
+      .put("algorithm", "ES256")
+      .put("buffer", Base64.getEncoder().encodeToString(PEM.getBytes(StandardCharsets.UTF_8)));
+
+    PubSecKeyOptions options = new PubSecKeyOptions(json);
+    assertEquals(PEM, options.getBuffer().toString(StandardCharsets.UTF_8));
+    // and the key material is usable
+    JWK jwk = new JWK(options);
+    assertEquals("ES256", jwk.getAlgorithm());
+    assertTrue(jwk.signingAlgorithm().canVerify());
+    assertFalse(jwk.signingAlgorithm().canSign());
+  }
+
+  @Test
+  public void testFromJsonWithRawPemIsRejected() {
+    // raw PEM text is not a valid base64 encoded buffer, users must encode it first (see testFromJsonWithBase64Pem)
+    JsonObject json = new JsonObject()
+      .put("algorithm", "ES256")
+      .put("buffer", PEM);
+
+    assertThrows(IllegalArgumentException.class, () -> new PubSecKeyOptions(json));
+  }
+}

--- a/vertx-auth-jwt/src/main/asciidoc/index.adoc
+++ b/vertx-auth-jwt/src/main/asciidoc/index.adoc
@@ -215,6 +215,20 @@ So you can do all operations with it:
 {@link examples.AuthJWTExamples#example18}
 ----
 
+=== Configuring keys from JSON
+
+All the options above can also be created from JSON, for example when the configuration is loaded from a file.
+Be aware that in JSON the `buffer` of a `PubSecKeyOptions` is a `Buffer`, and Buffers are represented in JSON as
+the **base64** encoding of their bytes, **not** as the PEM text itself. Passing the raw PEM text as `buffer` fails
+with `IllegalArgumentException: Illegal base64 character`.
+
+To obtain the JSON form of a key, encode the PEM (or secret) as base64, or let the options do it for you:
+
+[source,$lang]
+----
+{@link examples.AuthJWTExamples#example19}
+----
+
 === The JWT keystore file
 
 If you prefer to use Java Keystores, then you can do it either.

--- a/vertx-auth-jwt/src/main/java/examples/AuthJWTExamples.java
+++ b/vertx-auth-jwt/src/main/java/examples/AuthJWTExamples.java
@@ -17,6 +17,7 @@
 package examples;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.KeyStoreOptions;
@@ -265,5 +266,26 @@ public class AuthJWTExamples {
     String token = provider.generateToken(
       new JsonObject(),
       new JWTOptions().setAlgorithm("ES256"));
+  }
+
+  public void example19(Vertx vertx) {
+    String publicKeyPem =
+      "-----BEGIN PUBLIC KEY-----\n" +
+        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEraVJ8CpkrwTPRCPluUDdwC6b8+m4\n" +
+        "dEjwl8s+Sn0GULko+H95fsTREQ1A2soCFHS4wV3/23Nebq9omY3KuK9DKw==\n" +
+        "-----END PUBLIC KEY-----";
+
+    // the JSON representation of the key, "buffer" is base64 encoded:
+    // {"algorithm":"ES256","buffer":"LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0K..."}
+    JsonObject key = new PubSecKeyOptions()
+      .setAlgorithm("ES256")
+      .setBuffer(publicKeyPem)
+      .toJson();
+
+    // which can be stored in a config file and loaded back:
+    JsonObject config = new JsonObject()
+      .put("pubSecKeys", new JsonArray().add(key));
+
+    JWTAuth provider = JWTAuth.create(vertx, new JWTAuthOptions(config));
   }
 }

--- a/vertx-auth-jwt/src/test/java/io/vertx/tests/JWTAuthFromJsonTest.java
+++ b/vertx-auth-jwt/src/test/java/io/vertx/tests/JWTAuthFromJsonTest.java
@@ -1,0 +1,85 @@
+package io.vertx.tests;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.JWTOptions;
+import io.vertx.ext.auth.PubSecKeyOptions;
+import io.vertx.ext.auth.authentication.TokenCredentials;
+import io.vertx.ext.auth.jwt.JWTAuth;
+import io.vertx.ext.auth.jwt.JWTAuthOptions;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * A JWTAuth configured from JSON must behave exactly like one configured with the fluent setters. In JSON, the
+ * {@code buffer} of a {@code PubSecKeyOptions} is the base64 encoding of the PEM (or secret) bytes.
+ *
+ * @see <a href="https://github.com/eclipse-vertx/vertx-auth/issues/596">#596</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class JWTAuthFromJsonTest {
+
+  private static final String PUBLIC_PEM =
+    "-----BEGIN PUBLIC KEY-----\n" +
+      "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEraVJ8CpkrwTPRCPluUDdwC6b8+m4\n" +
+      "dEjwl8s+Sn0GULko+H95fsTREQ1A2soCFHS4wV3/23Nebq9omY3KuK9DKw==\n" +
+      "-----END PUBLIC KEY-----";
+
+  private static final String PRIVATE_PEM =
+    "-----BEGIN PRIVATE KEY-----\n" +
+      "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgeRyEfU1NSHPTCuC9\n" +
+      "rwLZMukaWCH2Fk6q5w+XBYrKtLihRANCAAStpUnwKmSvBM9EI+W5QN3ALpvz6bh0\n" +
+      "SPCXyz5KfQZQuSj4f3l+xNERDUDaygIUdLjBXf/bc15ur2iZjcq4r0Mr\n" +
+      "-----END PRIVATE KEY-----\n";
+
+  @Rule
+  public final RunTestOnContext rule = new RunTestOnContext();
+
+  private static String base64(String pem) {
+    return Base64.getEncoder().encodeToString(pem.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testTokenSignedWithSettersIsVerifiedByJsonConfig(TestContext should) {
+    JWTAuth signer = JWTAuth.create(rule.vertx(), new JWTAuthOptions()
+      .addPubSecKey(new PubSecKeyOptions()
+        .setAlgorithm("ES256")
+        .setBuffer(PRIVATE_PEM)));
+
+    // the same public key, this time given as JSON, e.g. loaded from a config file
+    JWTAuth verifier = JWTAuth.create(rule.vertx(), new JWTAuthOptions(new JsonObject()
+      .put("pubSecKeys", new JsonArray()
+        .add(new JsonObject()
+          .put("algorithm", "ES256")
+          .put("buffer", base64(PUBLIC_PEM))))));
+
+    String token = signer.generateToken(new JsonObject().put("sub", "paulo"), new JWTOptions().setAlgorithm("ES256"));
+
+    verifier.authenticate(new TokenCredentials(token))
+      .onComplete(should.asyncAssertSuccess(user -> should.assertEquals("paulo", user.subject())));
+  }
+
+  @Test
+  public void testJsonConfigIsIdenticalToSetterConfig() {
+    JWTAuthOptions fromSetters = new JWTAuthOptions()
+      .addPubSecKey(new PubSecKeyOptions()
+        .setAlgorithm("ES256")
+        .setBuffer(PUBLIC_PEM));
+
+    JWTAuthOptions fromJson = new JWTAuthOptions(new JsonObject()
+      .put("pubSecKeys", new JsonArray()
+        .add(new JsonObject()
+          .put("algorithm", "ES256")
+          .put("buffer", base64(PUBLIC_PEM)))));
+
+    org.junit.Assert.assertEquals(1, fromJson.getPubSecKeys().size());
+    org.junit.Assert.assertEquals(fromSetters.getPubSecKeys().get(0).toJson(), fromJson.getPubSecKeys().get(0).toJson());
+  }
+}


### PR DESCRIPTION
Fixes #596

`PubSecKeyOptions.buffer` is a `Buffer`, so its JSON representation is the base64 encoding of the key bytes (standard Vert.x `Buffer` ↔ JSON mapping via the generated converter), not the PEM text. That is consistent with the rest of Vert.x, but it was undocumented, and the docs' PEM examples lead users to paste the PEM into a JSON config and hit `IllegalArgumentException: Illegal base64 character` — exactly the report in #596 (the reporter eventually discovered the base64 form on their own).

This PR does not change behaviour; it documents it and pins it with tests:

- `PubSecKeyOptions` javadoc (class + both `setBuffer` overloads) explains the JSON representation and how to obtain it: `new PubSecKeyOptions().setBuffer(pem).toJson()`.
- vertx-auth-jwt docs: new "Configuring keys from JSON" subsection under "Loading Keys", with `AuthJWTExamples#example19`.
- `PubSecKeyOptionsTest` (common): setter → `toJson()` → JSON-constructor round trip, base64 PEM loads into a usable `JWK`, raw PEM in JSON is rejected.
- `JWTAuthFromJsonTest` (jwt): a JWTAuth built from JSON config verifies a token signed by the setter-configured twin, and the resulting `PubSecKeyOptions` are identical.

I deliberately did not add a "starts with `-----BEGIN`" heuristic to the JSON constructor: ambiguous decoding of key material in a security config type seems worse than a documented, uniform rule.