### PR TITLE
Honour and verify the WebAuthn user handle (user.id)

### DIFF
--- a/vertx-auth-webauthn4j/src/main/asciidoc/index.adoc
+++ b/vertx-auth-webauthn4j/src/main/asciidoc/index.adoc
@@ -94,6 +94,16 @@ The process takes 2 steps:
 
 If the solution is correct, the new authenticator should be added to the storage and be usable for login purposes.
 
+The `user` object given to `createCredentialsOptions` may contain an `id`: the https://www.w3.org/TR/webauthn/#user-handle[user handle],
+a stable, non user identifiable, identifier of the account (for example the primary key of the user record) encoded as
+`base64url` (at most 64 bytes). Browsers and authenticators use it to recognise that a credential belongs to an existing
+account, so it should be the same across registrations of the same user and different across users. When no `id` is given a
+random one is generated. Pass the same value in {@link io.vertx.ext.auth.webauthn4j.WebAuthn4JCredentials#setUserId(String)}
+when calling `authenticate` with the solution: it is stored in the
+{@link io.vertx.ext.auth.webauthn4j.Authenticator#setUserId(String)} property, returned in the principal of the authenticated
+user and, at login time, checked against the `userHandle` returned by the authenticator so that a credential can only be used
+by the account it was created for.
+
 == Login
 
 Like the registration, login is a 2 step process:

--- a/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/AuthenticatorConverter.java
+++ b/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/AuthenticatorConverter.java
@@ -17,6 +17,11 @@ public class AuthenticatorConverter {
             obj.setUsername((String)member.getValue());
           }
           break;
+        case "userId":
+          if (member.getValue() instanceof String) {
+            obj.setUserId((String)member.getValue());
+          }
+          break;
         case "type":
           if (member.getValue() instanceof String) {
             obj.setType((String)member.getValue());
@@ -68,6 +73,9 @@ public class AuthenticatorConverter {
    static void toJson(Authenticator obj, java.util.Map<String, Object> json) {
     if (obj.getUsername() != null) {
       json.put("username", obj.getUsername());
+    }
+    if (obj.getUserId() != null) {
+      json.put("userId", obj.getUserId());
     }
     if (obj.getType() != null) {
       json.put("type", obj.getType());

--- a/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/WebAuthn4JCredentialsConverter.java
+++ b/vertx-auth-webauthn4j/src/main/generated/io/vertx/ext/auth/webauthn4j/WebAuthn4JCredentialsConverter.java
@@ -27,6 +27,11 @@ public class WebAuthn4JCredentialsConverter {
             obj.setUsername((String)member.getValue());
           }
           break;
+        case "userId":
+          if (member.getValue() instanceof String) {
+            obj.setUserId((String)member.getValue());
+          }
+          break;
         case "origin":
           if (member.getValue() instanceof String) {
             obj.setOrigin((String)member.getValue());
@@ -54,6 +59,9 @@ public class WebAuthn4JCredentialsConverter {
     }
     if (obj.getUsername() != null) {
       json.put("username", obj.getUsername());
+    }
+    if (obj.getUserId() != null) {
+      json.put("userId", obj.getUserId());
     }
     if (obj.getOrigin() != null) {
       json.put("origin", obj.getOrigin());

--- a/vertx-auth-webauthn4j/src/main/java/examples/WebAuthN4JExamples.java
+++ b/vertx-auth-webauthn4j/src/main/java/examples/WebAuthN4JExamples.java
@@ -56,9 +56,9 @@ public class WebAuthN4JExamples {
 
     // some user
     JsonObject user = new JsonObject()
-      // id is expected to be a base64url string
+      // the user handle: a stable, non user identifiable, id of the account
+      // (base64url encoded, at most 64 bytes); generated when omitted
       .put("id", "000000000000000000000000")
-      .put("rawId", "000000000000000000000000")
       .put("name", "john.doe@email.com")
       // optionally
       .put("displayName", "John Doe")
@@ -112,6 +112,8 @@ public class WebAuthN4JExamples {
         new WebAuthn4JCredentials()
           // the username you want to link to
           .setUsername("paulo")
+          // the user handle (user.id) sent on the previous step, if any
+          .setUserId("000000000000000000000000")
           // the server origin
           .setOrigin("https://192.168.178.206.xip.io:8443")
           // the server domain

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/Authenticator.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/Authenticator.java
@@ -40,6 +40,17 @@ public class Authenticator {
   private String username;
 
   /**
+   * The user handle linked to this authenticator, as a base64url encoded string.
+   * <p>
+   * This is the {@code user.id} sent in the {@code PublicKeyCredentialCreationOptions} at registration time
+   * and the {@code userHandle} returned by the authenticator in the assertion response. It is a stable,
+   * non user identifiable, identifier of the account (see
+   * <a href="https://www.w3.org/TR/webauthn/#user-handle">https://www.w3.org/TR/webauthn/#user-handle</a>) and
+   * may be {@code null} for authenticators registered before this property was introduced.
+   */
+  private String userId;
+
+  /**
    * The type of key (must be "public-key")
    */
   private String type = "public-key";
@@ -93,6 +104,15 @@ public class Authenticator {
 
   public Authenticator setUsername(String username) {
     this.username = username;
+    return this;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public Authenticator setUserId(String userId) {
+    this.userId = userId;
     return this;
   }
 

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/WebAuthn4J.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/WebAuthn4J.java
@@ -58,7 +58,8 @@ public interface WebAuthn4J extends AuthenticationProvider {
    * <p>
    * The object being returned is described here <a href="https://w3c.github.io/webauthn/#dictdef-publickeycredentialcreationoptions">https://w3c.github.io/webauthn/#dictdef-publickeycredentialcreationoptions</a>
    *
-   * @param user    - the user object with name and optionally displayName and icon
+   * @param user    - the user object with name and optionally id (the base64url encoded user handle, generated when
+   *                absent), displayName and icon
    * @return a future notified with the encoded make credentials request
    */
   Future<JsonObject> createCredentialsOptions(JsonObject user);

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/WebAuthn4JCredentials.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/WebAuthn4JCredentials.java
@@ -28,6 +28,7 @@ public class WebAuthn4JCredentials implements Credentials {
   private String challenge;
   private JsonObject webauthn;
   private String username;
+  private String userId;
   private String origin;
   private String domain;
 
@@ -62,6 +63,23 @@ public class WebAuthn4JCredentials implements Credentials {
 
   public WebAuthn4JCredentials setUsername(String username) {
     this.username = username;
+    return this;
+  }
+
+  /**
+   * The user handle (base64url encoded) of the user performing the ceremony, if known.
+   * <p>
+   * At registration ({@code webauthn.create}) it is the {@code user.id} that was sent to the browser in the
+   * creation options and it is stored with the new authenticator. At authentication ({@code webauthn.get}) it
+   * is optional; when the relying party has identified the user before the ceremony, setting it ensures that
+   * the credential used belongs to that user.
+   */
+  public String getUserId() {
+    return userId;
+  }
+
+  public WebAuthn4JCredentials setUserId(String userId) {
+    this.userId = userId;
     return this;
   }
 

--- a/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/impl/WebAuthn4JImpl.java
+++ b/vertx-auth-webauthn4j/src/main/java/io/vertx/ext/auth/webauthn4j/impl/WebAuthn4JImpl.java
@@ -225,6 +225,43 @@ public class WebAuthn4JImpl implements WebAuthn4J {
     return base64UrlEncode(buffer.getBytes());
   }
 
+  /**
+   * A user handle is an opaque byte sequence of at most 64 bytes, and must not be empty
+   * (https://www.w3.org/TR/webauthn/#user-handle). In JSON it is carried as a base64url string.
+   *
+   * @throws IllegalArgumentException when the given value is not a valid user handle
+   */
+  private static void validateUserHandle(String userHandle) {
+    if (userHandle == null || userHandle.isEmpty()) {
+      throw new IllegalArgumentException("user handle cannot be empty");
+    }
+    final byte[] bytes;
+    try {
+      bytes = base64UrlDecode(userHandle);
+    } catch (RuntimeException e) {
+      throw new IllegalArgumentException("user handle must be base64url encoded", e);
+    }
+    if (bytes.length == 0) {
+      throw new IllegalArgumentException("user handle cannot be empty");
+    }
+    if (bytes.length > 64) {
+      throw new IllegalArgumentException("user handle cannot exceed 64 bytes");
+    }
+  }
+
+  /**
+   * Compares two base64url encoded user handles by value, so that different (padded/unpadded) encodings of the
+   * same bytes are considered equal.
+   */
+  private static boolean sameUserHandle(String a, String b) {
+    try {
+      return Arrays.equals(base64UrlDecode(a), base64UrlDecode(b));
+    } catch (RuntimeException e) {
+      // not base64url, fallback to plain comparison
+      return a.equals(b);
+    }
+  }
+
   @Override
   public WebAuthn4J credentialStorage(CredentialStorage credentialStorage) {
     if (credentialStorage == null) {
@@ -236,6 +273,19 @@ public class WebAuthn4JImpl implements WebAuthn4J {
 
   @Override
   public Future<JsonObject> createCredentialsOptions(JsonObject user) {
+
+    // the user handle: given by the relying party (base64url encoded) or generated
+    final String userId;
+    if (user.containsKey("id")) {
+      userId = user.getString("id");
+      try {
+        validateUserHandle(userId);
+      } catch (IllegalArgumentException e) {
+        return Future.failedFuture(new WebAuthn4JException("Invalid user.id: " + e.getMessage(), e));
+      }
+    } else {
+      userId = uUIDtoBase64Url(UUID.randomUUID());
+    }
 
 	  return credentialStorage.find(user.getString("name"), null)
       .map(authenticators -> {
@@ -252,7 +302,7 @@ public class WebAuthn4JImpl implements WebAuthn4J {
         putOpt(json.getJsonObject("rp"), "name", options.getRelyingParty().getName());
 
         // put non null values for User
-        putOpt(json.getJsonObject("user"), "id", uUIDtoBase64Url(UUID.randomUUID()));
+        putOpt(json.getJsonObject("user"), "id", userId);
         putOpt(json.getJsonObject("user"), "name", user.getString("name"));
         putOpt(json.getJsonObject("user"), "displayName", user.getString("displayName"));
         putOpt(json.getJsonObject("user"), "icon", user.getString("icon"));
@@ -438,6 +488,8 @@ public class WebAuthn4JImpl implements WebAuthn4J {
         			  // by default the store can upsert if a credential is missing, the user has been verified so it is valid
         			  // the store however might disallow this operation
         			  authrInfo.setUsername(username);
+        			  // the user handle sent to the browser in the creation options, if the relying party kept it
+        			  authrInfo.setUserId(authInfo.getUserId());
 
         			  // the create challenge is complete we can finally save this
         			  // new authenticator to the storage
@@ -473,6 +525,18 @@ public class WebAuthn4JImpl implements WebAuthn4J {
                 return Future.failedFuture("Cannot find authenticator with id: " + webauthn.getString("id"));
               } else if (authenticators.size() == 1) {
                 Authenticator authenticator = authenticators.get(0);
+                // https://www.w3.org/TR/webauthn/#sctn-verifying-assertion
+                // the user identified by the response userHandle (or by the relying party before the
+                // ceremony) must be the owner of the credential
+                if (authenticator.getUserId() != null) {
+                  final String userHandle = response.getString("userHandle");
+                  if (userHandle != null && !userHandle.isEmpty() && !sameUserHandle(authenticator.getUserId(), userHandle)) {
+                    return Future.failedFuture("User handle does not match the owner of credential id: " + credentialId);
+                  }
+                  if (authInfo.getUserId() != null && !sameUserHandle(authenticator.getUserId(), authInfo.getUserId())) {
+                    return Future.failedFuture("Credential id: " + credentialId + " does not belong to the expected user");
+                  }
+                }
                 return verifyWebAuthNGet(response, authInfo, clientDataJSON, authenticator)
                     .compose(counter -> {
                       // update the counter on the authenticator

--- a/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/UserHandleTest.java
+++ b/vertx-auth-webauthn4j/src/test/java/io/vertx/tests/UserHandleTest.java
@@ -1,0 +1,289 @@
+package io.vertx.tests;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.webauthn4j.Authenticator;
+import io.vertx.ext.auth.webauthn4j.RelyingParty;
+import io.vertx.ext.auth.webauthn4j.WebAuthn4J;
+import io.vertx.ext.auth.webauthn4j.WebAuthn4JCredentials;
+import io.vertx.ext.auth.webauthn4j.WebAuthn4JOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Base64;
+
+/**
+ * Tests for the user handle ({@code user.id}) handling: it must be taken from the caller when provided at
+ * registration (issue #580) and it must be stored, returned in the principal and verified against the
+ * assertion {@code userHandle} at authentication (issue #581).
+ */
+@RunWith(VertxUnitRunner.class)
+public class UserHandleTest {
+
+  // 16 bytes, base64url without padding
+  private static final String USER_ID = "AAECAwQFBgcICQoLDA0ODw";
+  private static final String OTHER_USER_ID = "Dw4NDAsKCQgHBgUEAwIBAA";
+
+  private static final String CRED_ID = "rYLaf9xagyA2YnO-W3CZDW8udSg8VeMMm25nenU7nCSxUqy1pEzOdb9oFrDxZZDmrp3odfuTPuONQCiSMH-Tyg";
+  private static final String PUBLIC_KEY = "pQECAyYgASFYILBNcdWmiMsmjA1QkNpG91GpEbhMIOqWLieDP6mLnGETIlggGMiqXz8BuSiPa0ovGVxxxbdUbJVm6THKNhUCifFhJCE";
+  private static final String ORIGIN = "https://192.168.178.206.xip.io:8443";
+  private static final String GET_CHALLENGE = "zNaIWnCmwVF7A5aZDF04_jthPmZTdziI7sXDkYEJxLDH1d1Eycc6kE_Rf1LZiSD0FGCrjzrYq9NmYrBmcDFF_g";
+
+  private final DummyStore database = new DummyStore();
+
+  @Rule
+  public final RunTestOnContext rule = new RunTestOnContext();
+
+  private WebAuthn4J webAuthN;
+
+  @Before
+  public void setUp() {
+    database.clear();
+    webAuthN = WebAuthn4J.create(
+        rule.vertx(),
+        new WebAuthn4JOptions().setRelyingParty(new RelyingParty().setName("ACME Corporation")))
+      .credentialStorage(database);
+  }
+
+  // ---- issue #580: createCredentialsOptions must honour user.id ----
+
+  @Test
+  public void testCreateOptionsUsesGivenUserId(TestContext should) {
+    final Async test = should.async();
+
+    JsonObject user = new JsonObject()
+      .put("id", USER_ID)
+      .put("name", "john.doe@email.com")
+      .put("displayName", "John Doe");
+
+    webAuthN
+      .createCredentialsOptions(user)
+      .onFailure(should::fail)
+      .onSuccess(options -> {
+        should.assertEquals(USER_ID, options.getJsonObject("user").getString("id"));
+        test.complete();
+      });
+  }
+
+  @Test
+  public void testCreateOptionsGeneratesUserIdWhenMissing(TestContext should) {
+    final Async test = should.async();
+
+    webAuthN
+      .createCredentialsOptions(new JsonObject().put("name", "john.doe@email.com"))
+      .onFailure(should::fail)
+      .onSuccess(options -> {
+        String id = options.getJsonObject("user").getString("id");
+        should.assertNotNull(id);
+        // valid base64url, 16 bytes (a UUID)
+        should.assertEquals(16, Base64.getUrlDecoder().decode(id).length);
+        // and different for every call
+        webAuthN
+          .createCredentialsOptions(new JsonObject().put("name", "john.doe@email.com"))
+          .onFailure(should::fail)
+          .onSuccess(options2 -> {
+            should.assertNotEquals(id, options2.getJsonObject("user").getString("id"));
+            test.complete();
+          });
+      });
+  }
+
+  @Test
+  public void testCreateOptionsRejectsNonBase64UrlUserId(TestContext should) {
+    final Async test = should.async();
+
+    webAuthN
+      .createCredentialsOptions(new JsonObject().put("id", "not base64url!").put("name", "john.doe@email.com"))
+      .onSuccess(options -> should.fail("user.id that is not base64url must be rejected"))
+      .onFailure(err -> test.complete());
+  }
+
+  @Test
+  public void testCreateOptionsRejectsTooLongUserId(TestContext should) {
+    final Async test = should.async();
+
+    // 65 bytes, the spec limits the user handle to 64 bytes
+    String tooLong = Base64.getUrlEncoder().withoutPadding().encodeToString(new byte[65]);
+
+    webAuthN
+      .createCredentialsOptions(new JsonObject().put("id", tooLong).put("name", "john.doe@email.com"))
+      .onSuccess(options -> should.fail("user.id longer than 64 bytes must be rejected"))
+      .onFailure(err -> test.complete());
+  }
+
+  @Test
+  public void testCreateOptionsRejectsEmptyUserId(TestContext should) {
+    final Async test = should.async();
+
+    webAuthN
+      .createCredentialsOptions(new JsonObject().put("id", "").put("name", "john.doe@email.com"))
+      .onSuccess(options -> should.fail("empty user.id must be rejected"))
+      .onFailure(err -> test.complete());
+  }
+
+  // ---- issue #581: registration stores the user id and exposes it in the principal ----
+
+  @Test
+  public void testRegisterStoresUserId(TestContext should) {
+    final Async test = should.async();
+
+    webAuthN
+      .authenticate(registrationCredentials().setUserId(USER_ID))
+      .onFailure(should::fail)
+      .onSuccess(user -> {
+        should.assertEquals(USER_ID, user.principal().getString("userId"));
+        database.find("paulo", null)
+          .onFailure(should::fail)
+          .onSuccess(authenticators -> {
+            should.assertEquals(1, authenticators.size());
+            should.assertEquals(USER_ID, authenticators.get(0).getUserId());
+            test.complete();
+          });
+      });
+  }
+
+  @Test
+  public void testRegisterWithoutUserIdIsStillAllowed(TestContext should) {
+    final Async test = should.async();
+
+    webAuthN
+      .authenticate(registrationCredentials())
+      .onFailure(should::fail)
+      .onSuccess(user -> {
+        should.assertNull(user.principal().getString("userId"));
+        test.complete();
+      });
+  }
+
+  // ---- issue #581: authentication verifies the assertion userHandle against the stored user id ----
+
+  @Test
+  public void testLoginMatchingUserHandle(TestContext should) {
+    final Async test = should.async();
+
+    database.add(storedAuthenticator().setUserId(USER_ID));
+
+    webAuthN
+      .authenticate(loginCredentials(USER_ID))
+      .onFailure(should::fail)
+      .onSuccess(user -> {
+        should.assertEquals(USER_ID, user.principal().getString("userId"));
+        test.complete();
+      });
+  }
+
+  @Test
+  public void testLoginMismatchingUserHandleIsRejected(TestContext should) {
+    final Async test = should.async();
+
+    database.add(storedAuthenticator().setUserId(USER_ID));
+
+    webAuthN
+      .authenticate(loginCredentials(OTHER_USER_ID))
+      .onSuccess(user -> should.fail("assertion userHandle does not match the credential owner"))
+      .onFailure(err -> test.complete());
+  }
+
+  @Test
+  public void testLoginMismatchingExpectedUserIdIsRejected(TestContext should) {
+    final Async test = should.async();
+
+    database.add(storedAuthenticator().setUserId(USER_ID));
+
+    // the relying party identified the user before the ceremony, but the credential belongs to someone else
+    webAuthN
+      .authenticate(loginCredentials(USER_ID).setUserId(OTHER_USER_ID))
+      .onSuccess(user -> should.fail("credential does not belong to the expected user"))
+      .onFailure(err -> test.complete());
+  }
+
+  @Test
+  public void testLoginMatchingExpectedUserId(TestContext should) {
+    final Async test = should.async();
+
+    database.add(storedAuthenticator().setUserId(USER_ID));
+
+    webAuthN
+      .authenticate(loginCredentials(USER_ID).setUserId(USER_ID))
+      .onFailure(should::fail)
+      .onSuccess(user -> test.complete());
+  }
+
+  @Test
+  public void testLoginLegacyAuthenticatorWithoutUserId(TestContext should) {
+    final Async test = should.async();
+
+    // authenticators registered before the user id was stored must keep working, whatever the userHandle
+    database.add(storedAuthenticator());
+
+    webAuthN
+      .authenticate(loginCredentials(OTHER_USER_ID))
+      .onFailure(should::fail)
+      .onSuccess(user -> {
+        should.assertNull(user.principal().getString("userId"));
+        test.complete();
+      });
+  }
+
+  @Test
+  public void testLoginEmptyUserHandleIsIgnored(TestContext should) {
+    final Async test = should.async();
+
+    // some authenticators return an empty user handle for non discoverable credentials
+    database.add(storedAuthenticator().setUserId(USER_ID));
+
+    webAuthN
+      .authenticate(loginCredentials(""))
+      .onFailure(should::fail)
+      .onSuccess(user -> test.complete());
+  }
+
+  // ---- fixtures ----
+
+  private static Authenticator storedAuthenticator() {
+    return new Authenticator()
+      .setUsername("paulo")
+      .setCredID(CRED_ID)
+      .setPublicKey(PUBLIC_KEY)
+      .setCounter(4);
+  }
+
+  private static WebAuthn4JCredentials loginCredentials(String userHandle) {
+    JsonObject response = new JsonObject()
+      .put("authenticatorData", "fxV8VVBPmz66RLzscHpg5yjRhO28Y_fPwYO5AVwzBEIBAAAACA")
+      .put("clientDataJSON", "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiek5hSVduQ213VkY3QTVhWkRGMDRfanRoUG1aVGR6aUk3c1hEa1lFSnhMREgxZDFFeWNjNmtFX1JmMUxaaVNEMEZHQ3JqenJZcTlObVlyQm1jREZGX2ciLCJvcmlnaW4iOiJodHRwczovLzE5Mi4xNjguMTc4LjIwNi54aXAuaW86ODQ0MyIsImNyb3NzT3JpZ2luIjpmYWxzZX0")
+      .put("signature", "MEUCIFXjL0ONRuLP1hkdlRJ8d0ofuRAS12c6w8WgByr-0yQZAiEAw-C6UZ8U8pi8irAcD6jXXaZMtezbzVwZXLGqY3sbFyA");
+    if (userHandle != null) {
+      response.put("userHandle", userHandle);
+    }
+    return new WebAuthn4JCredentials()
+      .setWebauthn(new JsonObject()
+        .put("id", CRED_ID)
+        .put("rawId", CRED_ID)
+        .put("type", "public-key")
+        .put("response", response))
+      .setUsername("paulo")
+      .setOrigin(ORIGIN)
+      .setChallenge(GET_CHALLENGE);
+  }
+
+  private static WebAuthn4JCredentials registrationCredentials() {
+    return new WebAuthn4JCredentials()
+      .setUsername("paulo")
+      .setOrigin(ORIGIN)
+      .setDomain("192.168.178.206.xip.io")
+      .setChallenge("BH7EKIDXU6Ct_96xTzG0l62qMhW_Ef_K4MQdDLoVNc1UXMQY4qN9ag5yDNmLI7vFRslkQbbj0JZWJxGVfMugXg")
+      .setWebauthn(new JsonObject()
+        .put("id", "Q-MHP0Xq20CKM5LW3qBt9gu5vdOYLNZc3jCcgyyLncRav5Ivd7T1dav3eWrI7CT8HmzU_yAYJrmja4in8OFL3A")
+        .put("rawId", "Q-MHP0Xq20CKM5LW3qBt9gu5vdOYLNZc3jCcgyyLncRav5Ivd7T1dav3eWrI7CT8HmzU_yAYJrmja4in8OFL3A")
+        .put("type", "public-key")
+        .put("response", new JsonObject()
+          .put("attestationObject", "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjEfxV8VVBPmz66RLzscHpg5yjRhO28Y_fPwYO5AVwzBEJBAAAAAwAAAAAAAAAAAAAAAAAAAAAAQEPjBz9F6ttAijOS1t6gbfYLub3TmCzWXN4wnIMsi53EWr-SL3e09XWr93lqyOwk_B5s1P8gGCa5o2uIp_DhS9ylAQIDJiABIVggN_D3u-03a0GzONOHfaML881QZtOCc5oTNRB2wlyqUEUiWCD3878XoO_bIJf0mEPDILODFhVmkc4QeR6hOIDvwvXzYQ")
+          .put("clientDataJSON", "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiQkg3RUtJRFhVNkN0Xzk2eFR6RzBsNjJxTWhXX0VmX0s0TVFkRExvVk5jMVVYTVFZNHFOOWFnNXlETm1MSTd2RlJzbGtRYmJqMEpaV0p4R1ZmTXVnWGciLCJvcmlnaW4iOiJodHRwczovLzE5Mi4xNjguMTc4LjIwNi54aXAuaW86ODQ0MyIsImNyb3NzT3JpZ2luIjpmYWxzZX0")));
+  }
+}


### PR DESCRIPTION
Fixes #580
Fixes #581

Both issues were filed against the old `vertx-auth-webauthn` module, but the behaviour carried over to `vertx-auth-webauthn4j`: `WebAuthn4JImpl.createCredentialsOptions()` ignored the `id` of the `user` object and always put a random UUID in `user.id`, even though the docs/example describe `id` as the caller-provided base64url user handle. As a result authenticators cannot recognise an existing account and create duplicate credentials for the same user (#580), and there is no stable id to key authenticators on or to check the assertion `userHandle` against (#581).

### #580 — `user.id` is honoured
- `createCredentialsOptions(user)` uses `user.id` when present; it is validated as a base64url string of 1..64 bytes (the spec's [user handle](https://www.w3.org/TR/webauthn/#user-handle) definition) and rejected with a clear error otherwise. When absent, a random UUID is generated as before.

### #581 — the user handle is carried through the flow
- `Authenticator` gains `userId` (base64url). It is stored via the existing `CredentialStorage.storeCredential` and, since the principal is `authenticator.toJson()`, exposed as `userId` in the authenticated `User`'s principal.
- `WebAuthn4JCredentials` gains `userId`:
  - `webauthn.create`: the relying party passes the `user.id` it sent to the browser (same way it passes `username`); it is stored on the new authenticator.
  - `webauthn.get`: optional; when the relying party identified the user before the ceremony, the credential must belong to that user.
- `webauthn.get` also verifies that the assertion's `response.userHandle`, when non-empty, matches the stored `userId` of the credential ([verifying an authentication assertion](https://www.w3.org/TR/webauthn/#sctn-verifying-assertion), step 6). Comparison is on decoded bytes so padded/unpadded encodings are equivalent.

### Compatibility
- Authenticators stored before this change have `userId == null` and are not subject to the check, so existing deployments keep working unchanged; empty user handles (non-discoverable credentials) are ignored.
- `CredentialStorage` is **not** changed (it is `@VertxGen` and implemented by users). Implementations that want to index by user id can do so from the `Authenticator` handed to `storeCredential`, and for discoverable-credential logins (`find(null, credentialId)`) the returned `Authenticator` now carries the owner's `userId`. This deviates from the issue's suggestion of adding the id to the storage query, deliberately, to avoid a breaking interface change — happy to revisit if you'd rather extend the interface.
- Generated converters were regenerated (`AuthenticatorConverter`, `WebAuthn4JCredentialsConverter`).

### Tests
`UserHandleTest` (13 tests, offline): given/generated/invalid (non-base64url, empty, >64 bytes) `user.id`; registration stores the id and exposes it in the principal (with and without id); login with matching / mismatching `userHandle`, matching / mismatching expected `userId`, legacy authenticator without `userId`, and empty `userHandle`. Existing suite unchanged (the only local failure was `EmulatorTest.testMetadata`, which hits the live FIDO MDS endpoint and was returning HTTP 429 to my IP — same on `master`).

Docs: registration section of the asciidoc, `WebAuthn4J#createCredentialsOptions` javadoc and the examples updated to describe the user handle.
