### PR TITLE
Improve test to avoid failures on CI

### DIFF
--- a/vertx-auth-common/src/test/java/io/vertx/tests/PermissionBasedAuthorizationTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/tests/PermissionBasedAuthorizationTest.java
@@ -12,6 +12,7 @@
  ********************************************************************************/
 package io.vertx.tests;
 
+import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.auth.User;
@@ -36,6 +37,9 @@ public class PermissionBasedAuthorizationTest {
 
   @Rule
   public final RunTestOnContext rule = new RunTestOnContext();
+
+  private HttpServer httpServer;
+  private HttpClient httpClient;
 
   @Test
   public void testConverter() {
@@ -81,17 +85,19 @@ public class PermissionBasedAuthorizationTest {
   public void testMatch1(TestContext should) {
     final Async test = should.async();
 
-    final HttpServer server = rule.vertx().createHttpServer();
-    server.requestHandler(request -> {
+    httpServer = rule.vertx().createHttpServer();
+    httpClient = rule.vertx().createHttpClient();
+
+    httpServer.requestHandler(request -> {
       User user = User.fromName("dummy user");
       user.authorizations().put("providerId", PermissionBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertEquals(true, PermissionBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();
     }).listen(0, "localhost").onComplete(should.asyncAssertSuccess(s -> {
-      rule.vertx().createHttpClient().request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r1").onComplete(should.asyncAssertSuccess(req -> {
+      httpClient.request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r1").onComplete(should.asyncAssertSuccess(req -> {
         req.send().onComplete(should.asyncAssertSuccess(res -> {
-          server.close().onComplete(close -> test.complete());
+          httpServer.close().onComplete(close -> test.complete());
         }));
       }));
     }));
@@ -101,17 +107,19 @@ public class PermissionBasedAuthorizationTest {
   public void testMatch2(TestContext should) {
     final Async test = should.async();
 
-    final HttpServer server = rule.vertx().createHttpServer();
-    server.requestHandler(request -> {
+    httpServer = rule.vertx().createHttpServer();
+    httpClient = rule.vertx().createHttpClient();
+
+    httpServer.requestHandler(request -> {
       User user = User.fromName("dummy user");
       user.authorizations().put("providerId", PermissionBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertEquals(false, PermissionBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();
     }).listen(0, "localhost").onComplete(should.asyncAssertSuccess(s -> {
-      rule.vertx().createHttpClient().request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r2").onComplete(should.asyncAssertSuccess(req -> {
+      httpClient.request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r2").onComplete(should.asyncAssertSuccess(req -> {
         req.send().onComplete(should.asyncAssertSuccess(res -> {
-          server.close().onComplete(close -> test.complete());
+          httpServer.close().onComplete(close -> test.complete());
         }));
       }));
     }));

--- a/vertx-auth-common/src/test/java/io/vertx/tests/RoleBasedAuthorizationTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/tests/RoleBasedAuthorizationTest.java
@@ -39,6 +39,9 @@ public class RoleBasedAuthorizationTest {
   @Rule
   public final RunTestOnContext rule = new RunTestOnContext();
 
+  private HttpServer httpServer;
+  private HttpClient httpClient;
+
   @Test
   public void testConverter() {
     TestUtils.testJsonCodec(RoleBasedAuthorization.create("role1"), RoleBasedAuthorizationConverter::encode,
@@ -76,19 +79,20 @@ public class RoleBasedAuthorizationTest {
   @Test
   public void testMatch1(TestContext should) {
     Async test = should.async();
-    HttpClient client = rule.vertx().createHttpClient();
 
-    final HttpServer server = rule.vertx().createHttpServer();
-    server.requestHandler(request -> {
+    httpServer = rule.vertx().createHttpServer();
+    httpClient = rule.vertx().createHttpClient();
+
+    httpServer.requestHandler(request -> {
       User user = User.fromName("dummy user");
       user.authorizations().put("providerId", Collections.singleton(RoleBasedAuthorization.create("p1").setResource("r1")));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertTrue(RoleBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();
     }).listen(0, "localhost").onComplete(should.asyncAssertSuccess(s -> {
-      client.request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r1").onComplete(should.asyncAssertSuccess(req -> {
+      httpClient.request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r1").onComplete(should.asyncAssertSuccess(req -> {
         req.send().onComplete(should.asyncAssertSuccess(res -> {
-          server.close().onComplete(close -> test.complete());
+          httpServer.close().onComplete(close -> test.complete());
         }));
       }));
     }));
@@ -98,18 +102,19 @@ public class RoleBasedAuthorizationTest {
   public void testMatch2(TestContext should) {
     Async test = should.async();
 
-    HttpServer server = rule.vertx().createHttpServer();
-    HttpClient client = rule.vertx().createHttpClient();
-    server.requestHandler(request -> {
+    httpServer = rule.vertx().createHttpServer();
+    httpClient = rule.vertx().createHttpClient();
+
+    httpServer.requestHandler(request -> {
       User user = User.fromName("dummy user");
       user.authorizations().put("providerId", Collections.singleton(RoleBasedAuthorization.create("p1").setResource("r1")));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertFalse(RoleBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();
     }).listen(0, "localhost").onComplete(should.asyncAssertSuccess(s -> {
-      client.request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r2").onComplete(should.asyncAssertSuccess(req -> {
+      httpClient.request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r2").onComplete(should.asyncAssertSuccess(req -> {
         req.send().onComplete(should.asyncAssertSuccess(res -> {
-          server.close().onComplete(close -> test.complete());
+          httpServer.close().onComplete(close -> test.complete());
         }));
       }));
     }));

--- a/vertx-auth-common/src/test/java/io/vertx/tests/WildcardPermissionBasedAuthorizationTest.java
+++ b/vertx-auth-common/src/test/java/io/vertx/tests/WildcardPermissionBasedAuthorizationTest.java
@@ -12,6 +12,7 @@
  ********************************************************************************/
 package io.vertx.tests;
 
+import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.ext.auth.User;
@@ -36,6 +37,9 @@ public class WildcardPermissionBasedAuthorizationTest {
 
   @Rule
   public final RunTestOnContext rule = new RunTestOnContext();
+
+  private HttpServer httpServer;
+  private HttpClient httpClient;
 
   @Test
   public void testConverter() {
@@ -107,17 +111,20 @@ public class WildcardPermissionBasedAuthorizationTest {
   @Test
   public void testMatch1(TestContext should) {
     final Async test = should.async();
-    final HttpServer server = rule.vertx().createHttpServer();
-    server.requestHandler(request -> {
+
+    httpServer = rule.vertx().createHttpServer();
+    httpClient = rule.vertx().createHttpClient();
+
+    httpServer.requestHandler(request -> {
       User user = User.fromName("dummy user");
       user.authorizations().put("providerId", WildcardPermissionBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertTrue(WildcardPermissionBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();
     }).listen(0, "localhost").onComplete(should.asyncAssertSuccess(s -> {
-      rule.vertx().createHttpClient().request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r1").onComplete(should.asyncAssertSuccess(req -> {
+      httpClient.request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r1").onComplete(should.asyncAssertSuccess(req -> {
         req.send().onComplete(should.asyncAssertSuccess(res -> {
-          server.close().onComplete(close -> test.complete());
+          httpServer.close().onComplete(close -> test.complete());
         }));
       }));
     }));
@@ -126,17 +133,20 @@ public class WildcardPermissionBasedAuthorizationTest {
   @Test
   public void testMatch2(TestContext should) {
     final Async test = should.async();
-    final HttpServer server = rule.vertx().createHttpServer();
-    server.requestHandler(request -> {
+
+    httpServer = rule.vertx().createHttpServer();
+    httpClient = rule.vertx().createHttpClient();
+
+    httpServer.requestHandler(request -> {
       User user = User.fromName("dummy user");
       user.authorizations().put("providerId", WildcardPermissionBasedAuthorization.create("p1").setResource("r1"));
       AuthorizationContext context = new AuthorizationContextImpl(user, request.params());
       should.assertFalse(WildcardPermissionBasedAuthorization.create("p1").setResource("{variable1}").match(context));
       request.response().end();
     }).listen(0, "localhost").onComplete(should.asyncAssertSuccess(s -> {
-      rule.vertx().createHttpClient().request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r2").onComplete(should.asyncAssertSuccess(req -> {
+      httpClient.request(HttpMethod.GET, s.actualPort(), "localhost", "/?variable1=r2").onComplete(should.asyncAssertSuccess(req -> {
         req.send().onComplete(should.asyncAssertSuccess(res -> {
-          server.close().onComplete(close -> test.complete());
+          httpServer.close().onComplete(close -> test.complete());
         }));
       }));
     }));


### PR DESCRIPTION
Keep a reference to HttpClient in the test class to prevent the JVM from closing it eagerly.